### PR TITLE
表示系タグのnullの扱いを見直し

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.0.4'
+version = '1.0.5'
 description = '画面オンライン処理方式を実現する。'
 
 

--- a/src/main/java/nablarch/common/web/tag/TagUtil.java
+++ b/src/main/java/nablarch/common/web/tag/TagUtil.java
@@ -1233,7 +1233,7 @@ public final class TagUtil {
         }
         String strValue = value.toString();
         for (Object element : values) {
-            if (strValue.equals(element.toString())) {
+            if (element != null && strValue.equals(element.toString())) {
                 return true;
             }
         }

--- a/src/test/java/nablarch/common/web/tag/CodeTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/CodeTagTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.Collections;
 import java.util.Locale;
 
 import javax.servlet.jsp.PageContext;
@@ -423,6 +424,42 @@ public class CodeTagTest extends TagTestSupport<CodeTag> {
         assertThat(TagTestUtil.getOutput(pageContext),
                    is("<ul><li>処理実行中</li><li>処理実行完了</li></ul>"));
     }
+    
+    @Test
+    public void testInputPageArrayWithNull() throws Exception {
+
+        TagTestUtil.setUpCodeTagTest();
+
+        ThreadContext.setLanguage(Locale.JAPANESE);
+
+        target.setName("array");
+        target.setCodeId("0002");
+        target.setListFormat("ul");
+
+        pageContext.getAttributes(PageContext.PAGE_SCOPE).put("array", new String[] {null});
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+        assertThat(TagTestUtil.getOutput(pageContext), is(""));
+    }
+    
+    @Test
+    public void testInputPageListWithNull() throws Exception {
+
+        TagTestUtil.setUpCodeTagTest();
+
+        ThreadContext.setLanguage(Locale.JAPANESE);
+
+        target.setName("list");
+        target.setCodeId("0002");
+        target.setListFormat("ul");
+
+        pageContext.getAttributes(PageContext.PAGE_SCOPE).put("list", Collections.singleton(null));
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+        assertThat(TagTestUtil.getOutput(pageContext), is(""));
+    }
 
     @Test
     public void testConfirmationPageForDefault() throws Exception {
@@ -663,6 +700,44 @@ public class CodeTagTest extends TagTestSupport<CodeTag> {
         target.setCodeId("0002");
 
         target.setListFormat("ul");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+        assertThat(TagTestUtil.getOutput(pageContext), is(""));
+    }
+    
+    @Test
+    public void testConfirmationPageArrayWithNull() throws Exception {
+
+        TagTestUtil.setUpCodeTagTest();
+
+        ThreadContext.setLanguage(Locale.JAPANESE);
+        TagUtil.setConfirmationPage(pageContext);
+
+        target.setName("array");
+        target.setCodeId("0002");
+        target.setListFormat("ul");
+
+        pageContext.getAttributes(PageContext.PAGE_SCOPE).put("array", new String[] {null});
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+        assertThat(TagTestUtil.getOutput(pageContext), is(""));
+    }
+
+    @Test
+    public void testConfirmationPageListWithNull() throws Exception {
+
+        TagTestUtil.setUpCodeTagTest();
+
+        ThreadContext.setLanguage(Locale.JAPANESE);
+        TagUtil.setConfirmationPage(pageContext);
+
+        target.setName("list");
+        target.setCodeId("0002");
+        target.setListFormat("ul");
+
+        pageContext.getAttributes(PageContext.PAGE_SCOPE).put("list", Collections.singleton(null));
 
         assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
         assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));

--- a/src/test/java/nablarch/common/web/tag/IncludeParamTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/IncludeParamTagTest.java
@@ -6,8 +6,10 @@ import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 
+import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
 
 import org.junit.Test;
@@ -202,6 +204,52 @@ public class IncludeParamTagTest extends TagTestSupport<IncludeParamTag> {
     }
 
     @Test
+    public void testInputPageArrayWithNull() throws Exception {
+        IncludeContext includeContext = new IncludeContext();
+        IncludeContext.setIncludeContext(pageContext, includeContext);
+        pageContext.getMockReq().getParams().put("entity.bbb", new String[] {null});
+
+        // nablarch
+        target.setName("entity.bbb");
+        target.setParamName("paramName_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(includeContext.getParams().size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").get(0), is(""));
+    }
+    
+    @Test
+    public void testInputPageListWithNull() throws Exception {
+        IncludeContext includeContext = new IncludeContext();
+        IncludeContext.setIncludeContext(pageContext, includeContext);
+
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        // nablarch
+        target.setName("list");
+        target.setParamName("paramName_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(includeContext.getParams().size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").get(0), is(""));
+    }
+
+    @Test
     public void testConfirmationPageUsingName() throws Exception {
 
         IncludeContext includeContext = new IncludeContext();
@@ -315,5 +363,56 @@ public class IncludeParamTagTest extends TagTestSupport<IncludeParamTag> {
         for (int i = 0; i < 3; i++) {
             assertThat(includeContext.getParams().get("paramName_test").get(i), is("val" + (i + 1)));
         }
+    }
+    
+    @Test
+    public void testConfirmationPageArrayWithNull() throws Exception {
+        IncludeContext includeContext = new IncludeContext();
+        IncludeContext.setIncludeContext(pageContext, includeContext);
+        TagUtil.setConfirmationPage(pageContext);
+
+        pageContext.getMockReq()
+                   .getParams()
+                   .put("entity.bbb", new String[] {null});
+
+        // nablarch
+        target.setName("entity.bbb");
+        target.setParamName("paramName_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(includeContext.getParams().size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").get(0), is(""));
+    }
+
+    @Test
+    public void testConfirmationPageListWithNull() throws Exception {
+        IncludeContext includeContext = new IncludeContext();
+        IncludeContext.setIncludeContext(pageContext, includeContext);
+        TagUtil.setConfirmationPage(pageContext);
+
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        // nablarch
+        target.setName("list");
+        target.setParamName("paramName_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(includeContext.getParams().size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").size(), is(1));
+        assertThat(includeContext.getParams().get("paramName_test").get(0), is(""));
     }
 }

--- a/src/test/java/nablarch/common/web/tag/ParamTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/ParamTagTest.java
@@ -1,14 +1,25 @@
 package nablarch.common.web.tag;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 
 import javax.servlet.jsp.tagext.Tag;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.hamcrest.collection.IsMapContaining;
+import org.hamcrest.core.IsCollectionContaining;
 
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 
@@ -115,7 +126,82 @@ public class ParamTagTest extends TagTestSupport<ParamTag> {
         assertThat(currentSubmissionInfo.getParamsMap().get("paramName_test").size(), is(1));
         assertThat(currentSubmissionInfo.getParamsMap().get("paramName_test").get(0), is("0.0000000001"));
     }
-    
+
+    @Test
+    public void testArrayWithNullValue() throws Exception {
+        pageContext.setAttribute("array", new String[] {null});
+        target.setName("array");
+        target.setParamName("array_param");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+
+        assertThat(currentSubmissionInfo.getParamsMap(), hasEntry(is("array_param"), contains("")));
+    }
+
+    @Test
+    public void testMultiArrayWithNullValue() throws Exception {
+        pageContext.setAttribute("array", new String[] {"a", null, "c"});
+        target.setName("array");
+        target.setParamName("array_param");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+
+        assertThat(currentSubmissionInfo.getParamsMap(), hasEntry(is("array_param"), contains("a", "", "c")));
+    }
+
+    @Test
+    public void testListWithNullValue() throws Exception {
+        pageContext.setAttribute("list", Collections.singletonList(null));
+        target.setName("list");
+        target.setParamName("list_param");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+
+        assertThat(currentSubmissionInfo.getParamsMap(), hasEntry(is("list_param"), contains("")));
+    }
+
+    @Test
+    public void testMultiListWithNullValue() throws Exception {
+        pageContext.setAttribute("list", Arrays.asList("あ", null, "う"));
+        target.setName("list");
+        target.setParamName("list_param");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+
+        assertThat(currentSubmissionInfo.getParamsMap(), hasEntry(is("list_param"), contains("あ", "", "う")));
+    }
+
+    @Test
+    public void testScopeValueIsNull() throws Exception {
+        pageContext.setAttribute("list", Arrays.asList("あ", null, "う"));
+        target.setName("not_found");
+        target.setParamName("param");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+
+        assertThat(currentSubmissionInfo.getParamsMap(), hasEntry(is("param"), contains("")));
+    }
+
     @Test
     public void testInputPageUsingValue() throws Exception {
         
@@ -225,8 +311,8 @@ public class ParamTagTest extends TagTestSupport<ParamTag> {
         String expected = "";
         TagTestUtil.assertTag(actual, expected, " ");
 
-        assertThat(currentSubmissionInfo.getParamsMap().size(), is(1));
         assertThat(currentSubmissionInfo.getParamsMap().get("paramName_test").size(), is(1));
+        assertThat(currentSubmissionInfo.getParamsMap().size(), is(1));
         assertThat(currentSubmissionInfo.getParamsMap().get("paramName_test").get(0), is("value_test"));
     }
     

--- a/src/test/java/nablarch/common/web/tag/PrettyPrintTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/PrettyPrintTagTest.java
@@ -3,6 +3,8 @@ package nablarch.common.web.tag;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Collections;
+
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
 
@@ -35,5 +37,116 @@ public class PrettyPrintTagTest extends TagTestSupport<PrettyPrintTag> {
         assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
         String actual = TagTestUtil.getOutput(pageContext);
         TagTestUtil.assertTag(actual, "&lt;script&gt;hoge&lt;/script&gt;", " ");
+    }
+    
+    /**
+     * 配列の単一要素に値がある場合その値が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageArrayWithValue() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {"abc"});
+
+        target.setName("array");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is("abc"));
+    }
+    
+    /**
+     * 配列の単一要素に値がある場合その値が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageListWithValue() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", Collections.singletonList("<a"));
+
+        target.setName("array");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is("&lt;a"));
+    }
+    
+    /**
+     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageArrayWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {null});
+
+        target.setName("array");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+
+    /**
+     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        target.setName("list");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+    
+    /**
+     * 確認画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testConfirmationPageArrayWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {null});
+
+        target.setName("array");
+
+        TagUtil.setConfirmationPage(pageContext);
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+
+    /**
+     * 確認画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testConfirmationPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        target.setName("list");
+
+        TagUtil.setConfirmationPage(pageContext);
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
     }
 }

--- a/src/test/java/nablarch/common/web/tag/RawWriteTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/RawWriteTagTest.java
@@ -3,6 +3,8 @@ package nablarch.common.web.tag;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Collections;
+
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
 
@@ -34,5 +36,98 @@ public class RawWriteTagTest extends TagTestSupport<RawWriteTag> {
         assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
         String actual = TagTestUtil.getOutput(pageContext);
         TagTestUtil.assertTag(actual, "<script>hoge</script>", " ");
+    }
+    
+    /**
+     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageArrayWithValue() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {"<script>hoge</script>"});
+
+        target.setName("array");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is("<script>hoge</script>"));
+    }
+    
+    /**
+     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageArrayWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {null});
+
+        target.setName("array");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+
+    /**
+     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        target.setName("list");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+    
+    /**
+     * 確認画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testConfirmationPageArrayWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {null});
+
+        target.setName("array");
+
+        TagUtil.setConfirmationPage(pageContext);
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+
+    /**
+     * 確認画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testConfirmationPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        target.setName("list");
+
+        TagUtil.setConfirmationPage(pageContext);
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
     }
 }

--- a/src/test/java/nablarch/common/web/tag/RawWriteTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/RawWriteTagTest.java
@@ -39,7 +39,7 @@ public class RawWriteTagTest extends TagTestSupport<RawWriteTag> {
     }
     
     /**
-     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * 入力画面で配列の要素が非nullの場合その値が出力されること
      * @throws Exception
      */
     @Test

--- a/src/test/java/nablarch/common/web/tag/SetTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/SetTagTest.java
@@ -1,9 +1,12 @@
 package nablarch.common.web.tag;
 
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
+import java.util.Collections;
 
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
@@ -138,6 +141,49 @@ public class SetTagTest extends TagTestSupport<SetTag> {
     }
 
     @Test
+    public void testInputPageArrayWithNull() throws Exception {
+        pageContext.getMockReq()
+                   .getParams()
+                   .put("entity.bbb", new String[] {null});
+
+        // nablarch
+        target.setName("entity.bbb");
+        target.setVar("var_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(pageContext.getAttribute("var_test", PageContext.REQUEST_SCOPE),
+                is(nullValue()));
+
+    }
+    
+    @Test
+    public void testInputPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("entity.bbb", Collections.singleton(null));
+
+        // nablarch
+        target.setName("entity.bbb");
+        target.setVar("var_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(pageContext.getAttribute("var_test", PageContext.REQUEST_SCOPE),
+                is(nullValue()));
+
+    }
+
+    @Test
     public void testConfirmationPageUsingName() throws Exception {
 
         pageContext.getMockReq().getParams().put("entity.bbb", new String[] {"value_test"});
@@ -252,5 +298,50 @@ public class SetTagTest extends TagTestSupport<SetTag> {
                 assertNull(o);
             }
         }
+    }
+    
+    @Test
+    public void testConfirmationPageArrayWithNull() throws Exception {
+        pageContext.getMockReq()
+                   .getParams()
+                   .put("entity.bbb", new String[] {null});
+        TagUtil.setConfirmationPage(pageContext);
+
+        // nablarch
+        target.setName("entity.bbb");
+        target.setVar("var_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(pageContext.getAttribute("var_test", PageContext.REQUEST_SCOPE),
+                is(nullValue()));
+
+    }
+
+    @Test
+    public void testConfirmationPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("entity.bbb", Collections.singleton(null));
+        TagUtil.setConfirmationPage(pageContext);
+
+        // nablarch
+        target.setName("entity.bbb");
+        target.setVar("var_test");
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertThat(pageContext.getAttribute("var_test", PageContext.REQUEST_SCOPE),
+                is(nullValue()));
+
     }
 }

--- a/src/test/java/nablarch/common/web/tag/TagUtilTest.java
+++ b/src/test/java/nablarch/common/web/tag/TagUtilTest.java
@@ -1,5 +1,43 @@
 package nablarch.common.web.tag;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TimeZone;
+import java.util.TreeSet;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.Tag;
+
+import org.hamcrest.Matchers;
+
 import nablarch.common.permission.BasicPermission;
 import nablarch.common.permission.Permission;
 import nablarch.common.permission.PermissionUtil;
@@ -19,45 +57,10 @@ import nablarch.fw.web.servlet.WebFrontController;
 import nablarch.test.support.log.app.OnMemoryLogWriter;
 import nablarch.test.support.web.servlet.MockServletContext;
 import nablarch.test.support.web.servlet.MockServletFilterConfig;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.servlet.http.HttpSession;
-import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.JspWriter;
-import javax.servlet.jsp.PageContext;
-import javax.servlet.jsp.tagext.Tag;
-import java.io.IOException;
-import java.lang.reflect.Array;
-import java.math.BigDecimal;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TimeZone;
-import java.util.TreeSet;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.hamcrest.Matchers;
 
 /**
  * @author Kiyohito Itoh
@@ -860,6 +863,9 @@ public class TagUtilTest {
         values.add("dummy");
         value = null;
         assertFalse(TagUtil.contains(values, value));
+        
+        assertFalse(TagUtil.contains(Arrays.asList(null, "abc", null), "aaa"));
+        assertTrue(TagUtil.contains(Arrays.asList(null, "abc", null), "abc"));
     }
 
     @Test

--- a/src/test/java/nablarch/common/web/tag/WriteTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/WriteTagTest.java
@@ -384,7 +384,7 @@ public class WriteTagTest extends TagTestSupport<WriteTag> {
     }
     
     /**
-     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * 入力画面でリストの要素がnullの場合は空文字列が出力されること
      * @throws Exception
      */
     @Test
@@ -506,7 +506,7 @@ public class WriteTagTest extends TagTestSupport<WriteTag> {
     }
 
     /**
-     * 確認画面で配列の要素がnullの場合は空文字列が出力されること
+     * 確認画面でリストの要素がnullの場合は空文字列が出力されること
      * @throws Exception
      */
     @Test

--- a/src/test/java/nablarch/common/web/tag/WriteTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/WriteTagTest.java
@@ -1,20 +1,22 @@
 package nablarch.common.web.tag;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Locale;
+
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.Tag;
+
 import nablarch.core.ThreadContext;
 import nablarch.core.repository.SystemRepository;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import javax.servlet.jsp.PageContext;
-import javax.servlet.jsp.tagext.Tag;
-import java.math.BigDecimal;
-import java.util.Date;
-import java.util.Locale;
-
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Kiyohito Itoh
@@ -364,6 +366,42 @@ public class WriteTagTest extends TagTestSupport<WriteTag> {
     }
 
     /**
+     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageArrayWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {null});
+
+        target.setName("array");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+    
+    /**
+     * 入力画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        target.setName("list");
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+
+    /**
      * 入力画面で、値がBigDecimal型かつエスケープしない場合に指数表記にならないこと。
      * @throws Exception
      */
@@ -445,5 +483,44 @@ public class WriteTagTest extends TagTestSupport<WriteTag> {
         String actual = TagTestUtil.getOutput(pageContext);
         String expected = "0.0000000001";
         TagTestUtil.assertTag(actual, expected, " ");
+    }
+    
+    /**
+     * 確認画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testConfirmationPageArrayWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("array", new String[] {null});
+
+        target.setName("array");
+        
+        TagUtil.setConfirmationPage(pageContext);
+
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
+    }
+
+    /**
+     * 確認画面で配列の要素がnullの場合は空文字列が出力されること
+     * @throws Exception
+     */
+    @Test
+    public void testConfirmationPageListWithNull() throws Exception {
+        pageContext.getAttributes(PageContext.REQUEST_SCOPE)
+                   .put("list", Collections.singletonList(null));
+
+        target.setName("list");
+
+        TagUtil.setConfirmationPage(pageContext);
+        target.doStartTag();
+        target.doEndTag();
+
+        final String actual = TagTestUtil.getOutput(pageContext);
+        assertThat(actual, is(""));
     }
 }


### PR DESCRIPTION
直してないやつ(スコープへのアクセスが無い子達ですよ):
 ✔ submitタグ (inputタグのボタン) 
 ✔ buttonタグ (buttonタグのボタン) 
 ✔ submitLinkタグ (リンク) 
 ✔ popupSubmitタグ (inputタグのボタン) 
 ✔ popupButtonタグ (buttonタグのボタン) 
 ✔ popupLinkタグ (リンク) 
 ✔ downloadSubmitタグ (inputタグのボタン) 
 ✔ downloadButtonタグ (buttonタグのボタン) 
 ✔ downloadLinkタグ (リンク) 
 ✔ changeParamNameタグ (ポップアップ用のサブミット時にパラメータ名の変更) 
 ✔ messageタグ (メッセージ) 
 ✔ errorsタグ (エラーメッセージの一覧表示) 
 ✔ errorタグ (エラーメッセージの個別表示) 
 ✔ aタグ 
 ✔ imgタグ 
 ✔ linkタグ 
 ✔ scriptタグ 
 ✔ noCacheタグ (ブラウザのキャッシュを抑制する) 
 ✔ setタグ (変数に値を設定する) 
 ✔ includeタグ (インクルード) 
 ✔ includeParamタグ (インクルード時に追加するパラメータの指定) 
 ✔ confirmationPageタグ (入力画面と確認画面を共通化) 
 ✔ ignoreConfirmationタグ (部分的に確認画面の画面状態を無効化する) 
 ✔ forInputPageタグ (入力画面のみボディを出力) 
 ✔ forConfirmationPageタグ (確認画面のみボディを出力) 

テストケース追加:
 ✔ paramタグ (サブミット時に追加するパラメータの指定) 
 ✔ writeタグ (オブジェクトの値) 
 ✔ prettyPrintタグ (オブジェクトの値。修飾系のHTML(bタグなど)のみエスケープしない) 
 ✔ rawWriteタグ (オブジェクトの値。HTMLエスケープしない) 
 ✔ codeタグ (コード値) 

#9 