### PR TITLE
change form.name to form.getAttribute['name']

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.0.5'
+version = '1.0.6'
 description = '画面オンライン処理方式を実現する。'
 
 

--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -744,7 +744,8 @@ public class FormTag extends GenericAttributesTagSupport {
             "    }",
 
                  // サブミット制御のJavaScriptの出力が完了したことを示すマーカを取得する。
-            "    if ($submissionEndMarkPrefix$[form.name] == null) {",
+            "    var formName = form.getAttribute('name');",
+            "    if ($submissionEndMarkPrefix$[formName] == null) {",
             "        return false;",
             "    }",
 
@@ -758,7 +759,7 @@ public class FormTag extends GenericAttributesTagSupport {
             "    var submitName = element.name;",
 
                  // フォームに含まれるサブミット情報を取得する。
-            "    var formData = $submissionInfoVar$[form.name];",
+            "    var formData = $submissionInfoVar$[formName];",
 
                  // イベント発生元のサブミット情報を取得する。
             "    var submissionData = formData[submitName];",

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -50,7 +50,8 @@ public class FormTagTest extends TagTestSupport<FormTag> {
             "    }",
 
                  // サブミット制御のJavaScriptの出力が完了したことを示すマーカを取得する。
-            "    if ($submissionEndMarkPrefix$[form.name] == null) {",
+            "    var formName = form.getAttribute('name');",
+            "    if ($submissionEndMarkPrefix$[formName] == null) {",
             "        return false;",
             "    }",
 
@@ -64,7 +65,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
             "    var submitName = element.name;",
 
                  // フォームに含まれるサブミット情報を取得する。
-            "    var formData = $submissionInfoVar$[form.name];",
+            "    var formData = $submissionInfoVar$[formName];",
 
                  // イベント発生元のサブミット情報を取得する。
             "    var submissionData = formData[submitName];",


### PR DESCRIPTION
change form.name to form.getAttribute['name']

Tested with the following browsers.

* chrome
* firefox
* ie11

NAB-15 n:formの子属性にid="name"やname="name"を持つ場合、nablarch_submitができない