### PR TITLE
change from.getAttribute('name') to form.attributes['name'].nodeValue

### DIFF
--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -744,7 +744,7 @@ public class FormTag extends GenericAttributesTagSupport {
             "    }",
 
                  // サブミット制御のJavaScriptの出力が完了したことを示すマーカを取得する。
-            "    var formName = form.getAttribute('name');",
+            "    var formName = form.attributes['name'].nodeValue;",
             "    if ($submissionEndMarkPrefix$[formName] == null) {",
             "        return false;",
             "    }",

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -50,7 +50,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
             "    }",
 
                  // サブミット制御のJavaScriptの出力が完了したことを示すマーカを取得する。
-            "    var formName = form.getAttribute('name');",
+            "    var formName = form.attributes['name'].nodeValue;",
             "    if ($submissionEndMarkPrefix$[formName] == null) {",
             "        return false;",
             "    }",


### PR DESCRIPTION
change from.getAttribute('name') to form.attributes['name'].nodeValue

Tested with the following browsers.

* chrome
* firefox
* ie11

NAB-15 n:formの子属性にid="name"やname="name"を持つ場合、nablarch_submitができない