### PR TITLE
トークンチェックによるCSRF防止機能を追加する

### DIFF
--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -14,6 +14,7 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
 
 import nablarch.common.util.WebRequestUtil;
+import nablarch.common.web.WebConfig;
 import nablarch.common.web.WebConfigFinder;
 import nablarch.common.web.exclusivecontrol.HttpExclusiveControlUtil;
 import nablarch.common.web.hiddenencryption.HiddenEncryptionUtil;
@@ -241,7 +242,9 @@ public class FormTag extends GenericAttributesTagSupport {
      * サブミット制御のJavaScriptの出力が完了する前にサブミットされることを防ぐため、
      * サブミット制御のJavaScriptの出力が完了したことを示すマーカを閉じタグの直後に出力する。
      * ここで出力したマーカをサブミット関数が参照し、サブミット可否の判定に使用する。
-     * 
+     *
+     * CSRFトークンがリクエスト属性に存在すればhiddenタグに追加する。
+     *
      * 楽観的ロックで使用するバージョン番号をhiddenタグに追加する。
      * 
      * ウィンドウスコープ変数のプレフィックスが指定されている場合は、リクエストパラメータからhiddenタグを出力する。
@@ -265,7 +268,9 @@ public class FormTag extends GenericAttributesTagSupport {
             outputCloseTag();
             return EVAL_PAGE;
         }
-        
+
+        setCsrfTokenToFormContext(pageContext);
+
         boolean printToken = useToken != null ? useToken : TagUtil.isConfirmationPage(pageContext);
         if (printToken) {
             setTokenToSessionAndFormContext(pageContext);
@@ -330,7 +335,21 @@ public class FormTag extends GenericAttributesTagSupport {
             formContext.addHiddenTagInfo(HttpExclusiveControlUtil.VERSION_PARAM_NAME, version);
         }
     }
-    
+
+    /**
+     * CSRFトークンがリクエスト属性に存在すればフォームコンテキストに設定する。
+     * @param pageContext ページコンテキスト
+     * @throws JspException JSP例外
+     */
+    private void setCsrfTokenToFormContext(PageContext pageContext) throws JspException {
+        WebConfig config = WebConfigFinder.getWebConfig();
+        Object csrfToken = pageContext.getRequest().getAttribute(config.getCsrfTokenSessionStoredVarName());
+        if (csrfToken != null) {
+            TagUtil.getFormContext(pageContext)
+                    .addHiddenTagInfo(config.getCsrfTokenParameterName(), csrfToken.toString());
+        }
+    }
+
     /**
      * トークンを生成し、セッションスコープとフォームコンテキストに設定する。
      * @param pageContext ページコンテキスト

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -15,6 +15,8 @@ import java.util.Map;
 
 import javax.servlet.jsp.tagext.Tag;
 
+import nablarch.common.web.WebConfig;
+import nablarch.common.web.WebConfigFinder;
 import nablarch.common.web.handler.MockPageContext;
 import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.hiddenencryption.HiddenEncryptionUtil;
@@ -22,6 +24,7 @@ import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
 import nablarch.fw.web.handler.KeitaiAccessHandler;
 
+import nablarch.test.support.web.servlet.MockServletRequest;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -2266,5 +2269,50 @@ public class FormTagTest extends TagTestSupport<FormTag> {
         // テストコードでリクエストパラメータのnullが空文字に置き変わっていることをassert出来ない。
         // そのため、doEndTag()が正常に終了することで問題ないことを確認する。
         assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+    }
+
+    /**
+     * CSRFトークンがリクエストスコープに格納されている場合は、CSRFトークンがhiddenタグに出力されること。
+     */
+    @Test
+    public void testInputPageForDefaultWithCsrfToken() throws Exception {
+
+        WebConfig webConfig = WebConfigFinder.getWebConfig();
+        MockServletRequest request = pageContext.getMockReq();
+        request.getAttributesMap().put(webConfig.getCsrfTokenSessionStoredVarName(), "csrf-token-test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String[] splitActual = actual.split(TagUtil.getCustomTagConfig().getLineSeparator());
+        String[] splitExpected = Builder.lines(
+                "",
+                "<script type=\"text/javascript\">",
+                "<!--",
+                SUBMIT_FUNCTION,
+                "-->",
+                "</script>",
+                Builder.lines(
+                        "<form",
+                        "name=\"nablarch_form1\"",
+                        "method=\"post\">").replace(Builder.LS, " "),
+                "<input type=\"hidden\" name=\"nablarch_hidden\" value=\"csrf-token=csrf-token-test\" />",
+                "<input type=\"hidden\" name=\"nablarch_submit\" value=\"\" />",
+                "<script type=\"text/javascript\">",
+                "<!--",
+                SUBMISSION_INFO_VAR + ".nablarch_form1 = {",
+                "};",
+                "-->",
+                "</script>",
+                "</form>",
+                "<script type=\"text/javascript\">",
+                "<!--",
+                SUBMISSION_END_MARK_PREFIX + ".nablarch_form1 = true;",
+                "-->",
+                "</script>").split(Builder.LS);;
+        for (int i = 0; i < splitActual.length; i++) {
+            TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
+        }
     }
 }

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -2032,6 +2032,12 @@ public class FormTagTest extends TagTestSupport<FormTag> {
         target.setAcceptCharset("acceptCharset_test");
         target.setTarget("target_test");
 
+        // GETリクエストの場合にCSRFトークンが出力されないことを確認するため、
+        // リクエスト属性にCSRFトークンを設定する。
+        WebConfig webConfig = WebConfigFinder.getWebConfig();
+        MockServletRequest request = pageContext.getMockReq();
+        request.getAttributesMap().put(webConfig.getCsrfTokenSessionStoredVarName(), "csrf-token-test");
+
         assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
         assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
 


### PR DESCRIPTION
https://github.com/nablarch/nablarch-fw-web/pull/70

上記PRのカスタムタグに対する変更です。

既存の二重サブミットのトークンと同じようにhiddenタグに出力してます。