### PR TITLE
内部クラスをstatic化

### DIFF
--- a/src/main/java/nablarch/common/web/tag/HtmlAttributes.java
+++ b/src/main/java/nablarch/common/web/tag/HtmlAttributes.java
@@ -31,7 +31,7 @@ public class HtmlAttributes {
     /** 動的属性を保持するマップ */
     private List<DynamicAttribute> dynamicAttributes = new ArrayList<DynamicAttribute>();
 
-    private final class DynamicAttribute {
+    private static final class DynamicAttribute {
         private String name;
         private Object value;
         private DynamicAttribute(String name, Object value) {


### PR DESCRIPTION
内部クラスがstaticになっていなかった。
staticでない内部クラスは不必要に外部クラスへの参照をもつことになるため、staticとした。