### PR TITLE
jetty11 対応が完了するまで bom から削除した jetty6 のバージョン指定を明記しておく修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
         <dependency>
           <groupId>com.nablarch.framework</groupId>
           <artifactId>nablarch-testing-jetty6</artifactId>
+          <!--
+            最終的には jetty11 に対応したアーティファクトに切り替えてバージョンは bom で管理する。
+            ここでバージョンを明記しているのは CI を通すための一次的な処置。
+          -->
+          <version>5-NEXT-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
bom から jetty6, jetty9 の記述を削除したことで、 jetty6 の version を省略していることが pom 定義上アウトになってエラーが発生するようになっている。
最終的には jetty11 に対応したプラグインに差し替えることになるので、それまでは version を明記しておく。