### PR TITLE
jetty11 対応が完了するまで bom から削除した jetty9 のバージョン指定を明記しておく修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
         <dependency>
           <groupId>com.nablarch.framework</groupId>
           <artifactId>nablarch-testing-jetty9</artifactId>
+          <!--
+            最終的には jetty11 に対応したアーティファクトに切り替えてバージョンは bom で管理する。
+            ここでバージョンを明記しているのは CI を通すための一次的な処置。
+          -->
+          <version>5-NEXT-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
[この修正に](https://github.com/nablarch/nablarch-fw-web-tag/pull/38) jetty9 の分が漏れていたので追加修正。