### PR TITLE
fix: 'No object wrapper identity on dispatch' 対応

### DIFF
--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.PageContext;
 
@@ -356,7 +357,8 @@ public class FormTag extends GenericAttributesTagSupport {
      */
     private void setTokenToSessionAndFormContext(PageContext pageContext) throws JspException {
         String name = WebConfigFinder.getWebConfig().getDoubleSubmissionTokenParameterName();
-        String token = TokenUtil.generateToken((NablarchHttpServletRequestWrapper) pageContext.getRequest());
+        final HttpServletRequest httpServletRequest = (HttpServletRequest) pageContext.getRequest();
+        String token = TokenUtil.generateToken(new NablarchHttpServletRequestWrapper(httpServletRequest));
         TagUtil.getFormContext(pageContext).addHiddenTagInfo(name, token);
     }
     

--- a/src/test/java/nablarch/common/web/tag/FormTagCustomizedDoubleSummitTokenTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagCustomizedDoubleSummitTokenTest.java
@@ -30,7 +30,6 @@ public class FormTagCustomizedDoubleSummitTokenTest extends TagTestSupport<FormT
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        pageContext = new MockPageContext(true);
         target.setPageContext(pageContext);
     }
 

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -239,7 +239,6 @@ public class FormTagTest extends TagTestSupport<FormTag> {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        pageContext = new MockPageContext(true);
         target.setPageContext(pageContext);
         TagUtil.getCustomTagConfig().setUseHiddenEncryption(false);
     }
@@ -1769,7 +1768,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
 
         // autocompleteDisableTarget = "password"の場合
 
-        pageContext = new MockPageContext(true);
+        pageContext = new MockPageContext();
         target = new FormTag();
         target.setPageContext(pageContext);
         TagUtil.getCustomTagConfig().setAutocompleteDisableTarget("password");


### PR DESCRIPTION
Servlet 6.0 で入った以下の変更に対する修正。

[No object wrapper identity on dispatch · Issue #411 · jakartaee/servlet](https://github.com/jakartaee/servlet/issues/411)

## 仕様の変更内容

- 従来、 `RequestDispatcher.forward` や `RequestDispatcher.include` が呼び出された場合、引数に渡されたリクエストやレスポンスオブジェクトは、呼び出し元から渡されたモノと同じモノが呼び出し先に渡されなければならなかった（コンテナが中で勝手に別オブジェクトに変更してはいけな縛り）
- Servlet 6.0 ではこの制限が緩和され、ラッパーオブジェクトを渡してもよくなった

参考

[Jakarta EE 10 - Jakarta Servlet 6.0 変更内容まとめ - A Memorandum](https://blog1.mammb.com/entry/2022/06/29/090000#%E3%81%9D%E3%81%AE%E4%BB%96%E3%81%AE%E5%A4%89%E6%9B%B4%E5%86%85%E5%AE%B9)
→「仕様書 6.2.2, “Wrapping Requests and Responses” の要件が緩和された」の部分


## Nablarch への影響

- `FormTag` 内で `PageContext` から取得した `ServletRequest` を `NablarchHttpServletRequestWrapper` にダウンキャストしているところがあった
- Tomcat 10.1.5 は問題なかったが、 Jetty 12 ではこの部分で `ClassCastException` が発生するようになった 
- 前述のとおり、仕様で `ServletRequest` の型が呼び出し元で渡したモノと同一になるとは限らなくなっており、 Jetty は実際に別のオブジェクトを渡すようになったためエラーとなった

## 修正内容

- 直接 `NablachHttpServletRequet` にキャストするのではなく、一旦 `HttpServletRequest` にキャストしてから `FormTag` 内部で `NablarchHttpServletRequest` でラップするように修正
