### PR TITLE
イベントが発生した要素ではなく、イベントハンドラを紐付けた要素を対象とするように修正

### DIFF
--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -776,7 +776,7 @@ public class FormTag extends GenericAttributesTagSupport {
                  // HTMLタグのイベントハンドラに直接設定する実装からscriptタグに移した際に
                  // 後方互換を保つためにeventから対象の要素を取得する
             "    if (element == null) {",
-            "        element = event.target;",
+            "        element = event.currentTarget;",
             "    }",
 
             "    var isAnchor = element.tagName.match(/a/i);",

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -52,7 +52,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
             // サブミット時に呼ばれる関数
             "function $fwPrefix$submit(event, element) {",
             "    if (element == null) {",
-            "        element = event.target;",
+            "        element = event.currentTarget;",
             "    }",
 
             "    var isAnchor = element.tagName.match(/a/i);",


### PR DESCRIPTION
現在の`FormTag`が生成するJavaScriptでは`Event#target`を使ってイベントが発生した要素を取得しています。

[Event: target プロパティ](https://developer.mozilla.org/ja/docs/Web/API/Event/target)

```javascript
function nablarch_submit(event, element) {
    if (element == null) {
        element = event.target;
    }
```

そして、この`nablarch_submit`関数をイベントハンドラとして要素に紐づけています。

```javascript
document.querySelector("form[name='nablarch_form2'] a[name='nablarch_form2_1']").onclick = window.nablarch_submit;
```

`button`などであればこれでも問題ないのですが、以下のようにな構成を取ると（Nablarch Example Webのダウンロード機能がこれに近い構成をしています）問題になります。

JSP

```html
<n:form method="POST" ...>
  ...

  <n:downloadLink uri="/action/project/download">
      <n:write name="label" />
      <n:img src="/images/download.png" alt="ダウンロード" />
  </n:downloadLink>
</n:form>
```

生成されるHTML

```html
<form... method="POST">
  ...
  <a name="nablarch_form2_1" href="/action/project/download2">
    <img src="/images/download.png)" alt="ダウンロード" />
  </a>
</form>
```

ここでクリックを行うと以下の状態になります。

- クリックされたと認識されるのは`img`タグ → `Event#target`は`img` elementになる
- イベントハンドラを紐づけたのは`a`タグであり、`nablarch_submit`もイベントハンドラを紐づけた要素そのものを`element`変数として渡されることを期待している
  - もともとは `<a ... onclick="return window.nablarch_submit(event, this);"></a>` だったので

よって、この状態だと処理対象の要素がずれるので`nablarch_submit`が動作しなくなります。

このため、イベントが発生した要素（`Event#target`）ではなくイベントハンドラを設定した要素（`Event#currentTarget`）を取得するように生成される`nablarch_submit`関数を修正しました。

[Event: currentTarget プロパティ](https://developer.mozilla.org/ja/docs/Web/API/Event/currentTarget)

### 互換性に関する確認

少し気になったので確認してみましたが、IE 11ではこのプロパティは動作しません。  
修正後の以下のコードは`element`が`null`、すなわちCSP nonce生成時にスクリプトを`script`タグに移動した場合に動作するケースになるので、やはりCSP対応を有効にするとIE 11では動作しないことになります。  
※ `document.querySelector`はIE 11では動作しますが、互換モードで実行されるとやはり動作しませんでした

```javascript
function nablarch_submit(event, element) {
    if (element == null) {
        element = event.currenTarget;
    }
```