### PR TITLE
CSP対応したdevelopをマージ

### DIFF
--- a/src/main/java/nablarch/common/web/tag/ButtonTagSupport.java
+++ b/src/main/java/nablarch/common/web/tag/ButtonTagSupport.java
@@ -22,6 +22,9 @@ public abstract class ButtonTagSupport extends FocusAttributesTagSupport {
     /** URIをhttpsにするか否か */
     private Boolean secure = null;
 
+    /** カスタムタグが生成するデフォルトのsubmit関数呼び出しを抑制するか否か。抑制する場合は{@code true} */
+    private boolean suppressDefaultSubmit = false;
+
     /**
      * サブミット先のURIを設定する。
      * @param uri サブミット先のURI
@@ -36,6 +39,16 @@ public abstract class ButtonTagSupport extends FocusAttributesTagSupport {
      */
     public void setSecure(Boolean secure) {
         this.secure = secure;
+    }
+
+    /**
+     * カスタムタグが生成するデフォルトのsubmit関数呼び出しを抑制するか否かを設定する。
+     * 抑制する場合は{@code true}。
+     *
+     * @param suppressDefaultSubmit カスタムタグが生成するデフォルトのsubmit関数呼び出しを抑制するか否か
+     */
+    public void setSuppressDefaultSubmit(boolean suppressDefaultSubmit) {
+        this.suppressDefaultSubmit = suppressDefaultSubmit;
     }
 
     /**
@@ -104,20 +117,25 @@ public abstract class ButtonTagSupport extends FocusAttributesTagSupport {
      * </pre>
      */
     public int doStartTag() throws JspException {
-
         checkChildElementsOfForm();
+
+        String tagName = "button";
         String requestId = WebRequestUtil.getRequestId(uri);
         String encodedUri = TagUtil.encodeUri(pageContext, uri, secure);
-        TagUtil.editOnclickAttributeForSubmission(pageContext, getAttributes());
+
         DisplayMethod displayMethodResult = TagUtil.getDisplayMethod(requestId, displayMethod);
         setSubmissionInfoToFormContext(requestId, encodedUri, displayMethodResult);
+
+        // サブミット情報を追加した後にスクリプトの生成を行う
+        TagUtil.registerOnclickForSubmission(pageContext, tagName, getAttributes(), suppressDefaultSubmit);
 
         if (DisplayMethod.DISABLED == displayMethodResult) {
             getAttributes().put(HtmlAttribute.DISABLED, true);
         } else if (DisplayMethod.NODISPLAY == displayMethodResult) {
             return SKIP_BODY;
         }
-        TagUtil.print(pageContext, TagUtil.createStartTag("button", getAttributes()));
+
+        TagUtil.print(pageContext, TagUtil.createStartTag(tagName, getAttributes()));
 
         return EVAL_BODY_INCLUDE;
     }

--- a/src/main/java/nablarch/common/web/tag/CspNonceTag.java
+++ b/src/main/java/nablarch/common/web/tag/CspNonceTag.java
@@ -1,0 +1,56 @@
+package nablarch.common.web.tag;
+
+import jakarta.servlet.jsp.JspException;
+
+/**
+ * セキュアハンドラがCSP向けのnonceを生成した場合にnonceを出力するクラス
+ */
+public class CspNonceTag extends HtmlTagSupport {
+    /**
+     * nonceを出力する際に nonce- をprefixとして付与するか否か。ポリシーのsrcとして使用することを想定
+     */
+    private Boolean sourceFormat = false;
+
+    /**
+     * nonceを出力する際に nonce- をprefixとして付与するか否か
+     *
+     * @return nonceを出力する際に nonce- をprefixとして付与するか否か
+     */
+    public Boolean getSourceFormat() {
+        return sourceFormat;
+    }
+
+    /**
+     * nonceを出力する際に nonce- をprefixとして付与するか否か。
+     * デフォルトは{@code false}で出力しない
+     *
+     * @param sourceFormat nonceを出力する際に nonce- をprefixとして付与するか否か
+     */
+    public void setSourceFormat(Boolean sourceFormat) {
+        this.sourceFormat = sourceFormat;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <br>
+     * セキュアハンドラがCSP向けのnonceを生成している場合（リクエストスコープにnonceが設定されている場合）に
+     * nonceを出力する。{@code sourceFormat}プロパティが{@code true}の場合は、ポリシー向けに nonce- を
+     * prefixとして付与して出力する
+     */
+    @Override
+    public int doStartTag() throws JspException {
+        if (TagUtil.hasCspNonce(pageContext)) {
+            String outputNonce;
+
+            if (sourceFormat != null && sourceFormat) {
+                outputNonce = "nonce-" + TagUtil.getCspNonce(pageContext);
+            } else {
+                outputNonce = TagUtil.getCspNonce(pageContext);
+            }
+
+            TagUtil.print(pageContext, TagUtil.escapeHtml(outputNonce));
+        }
+
+        return SKIP_BODY;
+    }
+}

--- a/src/main/java/nablarch/common/web/tag/CustomTagConfig.java
+++ b/src/main/java/nablarch/common/web/tag/CustomTagConfig.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import nablarch.core.util.StringUtil;
+import nablarch.fw.web.handler.SecureHandler;
 import nablarch.fw.web.i18n.DirectoryBasedResourcePathRule;
 import nablarch.fw.web.i18n.ResourcePathRule;
 
@@ -17,7 +18,6 @@ import static nablarch.fw.ExecutionContext.FW_PREFIX;
  * @author Kiyohito Itoh
  */
 public class CustomTagConfig {
-    
     /** errorタグと入力項目タグのerrorCss属性のデフォルト値 */
     private String errorCss = FW_PREFIX + "error";
     

--- a/src/main/java/nablarch/common/web/tag/FormContext.java
+++ b/src/main/java/nablarch/common/web/tag/FormContext.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.StringUtil;
 
-
 /**
  * フォームのコンテキスト情報を保持するクラス。<br>
  * このコンテキスト情報はページコンテキストに格納する。
@@ -36,6 +35,9 @@ public class FormContext {
     
     /** カレントのサブミット情報 */
     private SubmissionInfo currentSubmissionInfo;
+
+    /** サブミット用のスクリプト。CSP対応用nonce生成時に、このリストにためこみ一括出力する */
+    private final List<String> inlineSubmissionScripts = new ArrayList<String>();
     
     /**
      * コンストラクタ。
@@ -187,5 +189,23 @@ public class FormContext {
             }
         }
         return null;
+    }
+
+    /**
+     * サブミット用のスクリプトを登録する。
+     *
+     * @param script サブミット用のスクリプト
+     */
+    public void addInlineSubmissionScript(String script) {
+        inlineSubmissionScripts.add(script);
+    }
+
+    /**
+     * これまでに登録されたサブミット用のスクリプト群を返却する。
+     *
+     * @return サブミット用のスクリプト群
+     */
+    public List<String> getInlineSubmissionScripts() {
+        return inlineSubmissionScripts;
     }
 }

--- a/src/main/java/nablarch/common/web/tag/HtmlAttribute.java
+++ b/src/main/java/nablarch/common/web/tag/HtmlAttribute.java
@@ -254,7 +254,10 @@ public enum HtmlAttribute {
     AUTOFOCUS,
 
     /** placeholder属性 */
-    PLACEHOLDER;
+    PLACEHOLDER,
+
+    /** nonce属性 */
+    NONCE;
 
     /**
      * XHTMLの属性名を取得する。

--- a/src/main/java/nablarch/common/web/tag/ScriptTag.java
+++ b/src/main/java/nablarch/common/web/tag/ScriptTag.java
@@ -12,7 +12,7 @@ public class ScriptTag extends HtmlTagSupport {
     
     /** URIをhttpsにするか否か */
     private Boolean secure = null;
-    
+
     /**
      * URIをhttpsにするか否かを設定する。
      * @param secure httpsにする場合はtrue、しない場合はfalse。
@@ -95,10 +95,15 @@ public class ScriptTag extends HtmlTagSupport {
         if (hasSrc) {
             TagUtil.overrideUriAttribute(pageContext, getAttributes(), HtmlAttribute.SRC, secure);
         }
+
+
+        if (TagUtil.hasCspNonce(pageContext)) {
+            attributes.put(HtmlAttribute.NONCE, TagUtil.getCspNonce(pageContext));
+        }
         
         StringBuilder sb = new StringBuilder();
         sb.append(TagUtil.createStartTag("script", getAttributes()));
-        
+
         if (!hasSrc) {
             CustomTagConfig config = TagUtil.getCustomTagConfig();
             sb.append(config.getLineSeparator())

--- a/src/main/java/nablarch/common/web/tag/SubmitLinkTagSupport.java
+++ b/src/main/java/nablarch/common/web/tag/SubmitLinkTagSupport.java
@@ -23,6 +23,9 @@ public abstract class SubmitLinkTagSupport extends FocusAttributesTagSupport imp
     /** {@link BodyContent} */
     private BodyContent bodyContent;
 
+    /** カスタムタグが生成するデフォルトのsubmit関数呼び出しを抑制するか否か。抑制する場合は{@code true} */
+    private boolean suppressDefaultSubmit = false;
+
     /**
      * サブミット先のURIを設定する。
      * @param uri サブミット先のURI
@@ -37,6 +40,16 @@ public abstract class SubmitLinkTagSupport extends FocusAttributesTagSupport imp
      */
     public void setSecure(Boolean secure) {
         this.secure = secure;
+    }
+
+    /**
+     * カスタムタグが生成するデフォルトのsubmit関数呼び出しを抑制するか否かを設定する。
+     * 抑制する場合は{@code true}。
+     *
+     * @param suppressDefaultSubmit カスタムタグが生成するデフォルトのsubmit関数呼び出しを抑制するか否か
+     */
+    public void setSuppressDefaultSubmit(boolean suppressDefaultSubmit) {
+        this.suppressDefaultSubmit = suppressDefaultSubmit;
     }
 
     /**
@@ -97,6 +110,8 @@ public abstract class SubmitLinkTagSupport extends FocusAttributesTagSupport imp
         }
 
         checkChildElementsOfForm();
+
+        String tagName = "a";
         String requestId = WebRequestUtil.getRequestId(uri);
         if (requestId == null) {
             // サブミット制御では、リクエストIDがnullになるuriを許容しない。
@@ -107,9 +122,11 @@ public abstract class SubmitLinkTagSupport extends FocusAttributesTagSupport imp
         }
         String encodedUri = TagUtil.encodeUri(pageContext, uri, secure);
         getAttributes().put(HtmlAttribute.HREF, encodedUri);
-        TagUtil.editOnclickAttributeForSubmission(pageContext, getAttributes());
         DisplayMethod displayMethodResult = TagUtil.getDisplayMethod(requestId, displayMethod);
         setSubmissionInfoToFormContext(requestId, encodedUri, displayMethodResult);
+
+        // サブミット情報を追加した後にスクリプトの生成を行う
+        TagUtil.registerOnclickForSubmission(pageContext, tagName, getAttributes(), suppressDefaultSubmit);
 
         switch (displayMethodResult) {
         case DISABLED:
@@ -119,7 +136,7 @@ public abstract class SubmitLinkTagSupport extends FocusAttributesTagSupport imp
         case NODISPLAY:
             return SKIP_BODY;
         default:
-            TagUtil.print(pageContext, TagUtil.createStartTag("a", getAttributes()));
+            TagUtil.print(pageContext, TagUtil.createStartTag(tagName, getAttributes()));
             return EVAL_BODY_INCLUDE;
         }
     }

--- a/src/main/java/nablarch/common/web/tag/TagUtil.java
+++ b/src/main/java/nablarch/common/web/tag/TagUtil.java
@@ -824,7 +824,7 @@ public final class TagUtil {
         javaScript.append("'] ");
         javaScript.append(tagName);
         javaScript.append("[name='");
-        javaScript.append((String) attributes.get(HtmlAttribute.NAME));
+        javaScript.append(attributes.<String>get(HtmlAttribute.NAME));
         // 通常addEventListenerを使うところだが、従来の実装がonclick属性に直接設定するものだったため、
         // 動作を近いものにするためにonclickプロパティを使用している
         javaScript.append("']\").onclick = window.");

--- a/src/main/resources/META-INF/nablarch.tld
+++ b/src/main/resources/META-INF/nablarch.tld
@@ -4415,6 +4415,11 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
   
   <tag>
@@ -4603,6 +4608,11 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
   
   <tag>
@@ -4786,6 +4796,11 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
   
   <tag>
@@ -4945,6 +4960,11 @@
     </attribute>
     <attribute>
       <name>displayMethod</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
@@ -5115,6 +5135,11 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
   
   <tag>
@@ -5277,6 +5302,11 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
   
   <tag>
@@ -5425,6 +5455,11 @@
     </attribute>
     <attribute>
       <name>displayMethod</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
@@ -5584,6 +5619,11 @@
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
   </tag>
   
   <tag>
@@ -5732,6 +5772,11 @@
     </attribute>
     <attribute>
       <name>displayMethod</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
+    <attribute>
+      <name>suppressDefaultSubmit</name>
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>
@@ -7288,6 +7333,16 @@
     </attribute>
     <attribute>
       <name>withHtmlFormat</name>
+      <required>false</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
+  </tag>
+  <tag>
+    <name>cspNonce</name>
+    <tag-class>nablarch.common.web.tag.CspNonceTag</tag-class>
+    <body-content>empty</body-content>
+    <attribute>
+      <name>sourceFormat</name>
       <required>false</required>
       <rtexprvalue>true</rtexprvalue>
     </attribute>

--- a/src/test/java/nablarch/common/web/tag/ButtonTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/ButtonTagTest.java
@@ -5,16 +5,19 @@ import nablarch.common.permission.Permission;
 import nablarch.common.permission.PermissionUtil;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.Builder;
+import nablarch.fw.web.handler.SecureHandler;
 import nablarch.test.support.web.WebTestUtil;
 import org.junit.Test;
 
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
+import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -219,6 +222,46 @@ public class ButtonTagTest extends TagTestSupport<ButtonTag> {
     }
 
     /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接buttonタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // button
+        target.setName("name_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] button[name='name_test']\").onclick = window.nablarch_submit;"));
+    }
+
+    /**
      * サロゲートペアを扱うテストケース。
      * @throws Exception
      */
@@ -392,6 +435,262 @@ public class ButtonTagTest extends TagTestSupport<ButtonTag> {
         assertThat(info.getName(), is("name_test"));
         assertThat(info.getUri(), is("http://nablarch.co.jp" + WebTestUtil.CONTEXT_PATH + "/R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
         assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+
+        TagTestUtil.setUpDefaultConfig();
+
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // button
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        // スクリプトは登録されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        // スクリプトは登録されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        // スクリプトは登録されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+
+        TagTestUtil.setUpDefaultConfig();
+
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // button
+        target.setName("name_test");
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"></button>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される（CSP対応用のnonceを含めている） */
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionInfo.SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
     }
 
     @Test

--- a/src/test/java/nablarch/common/web/tag/CspNonceTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/CspNonceTagTest.java
@@ -1,0 +1,72 @@
+package nablarch.common.web.tag;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.PageContext;
+import jakarta.servlet.jsp.tagext.Tag;
+
+import nablarch.fw.web.handler.SecureHandler;
+import org.junit.Test;
+
+/**
+ * {@link CspNonceTag}のテスト。
+ */
+public class CspNonceTagTest extends TagTestSupport<CspNonceTag> {
+    public CspNonceTagTest() {
+        super(new CspNonceTag());
+    }
+
+    /**
+     * nonceがリクエストスコープにない場合には、出力が空になることを確認する。
+     *
+     * @throws JspException
+     */
+    @Test
+    public void noCspNonce() throws JspException {
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "";
+        TagTestUtil.assertTag(actual, expected, " ");
+    }
+
+    /**
+     * nonceがリクエストスコープにある場合には、nonceが出力されることを確認する。
+     *
+     * @throws JspException
+     */
+    @Test
+    public void hasCspNonce() throws JspException {
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "abcde";
+        TagTestUtil.assertTag(actual, expected, " ");
+    }
+
+    /**
+     * nonceがリクエストスコープにあり、{@code sourceFormat}を{@code true}にした場合には、
+     * nonce- prefix付きでnonceが出力されることを確認する。
+     *
+     * @throws JspException
+     */
+    @Test
+    public void hasCspNonceSourceFormat() throws JspException {
+        target.setSourceFormat(true);
+
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.SKIP_BODY));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = "nonce-abcde";
+        TagTestUtil.assertTag(actual, expected, " ");
+    }
+}

--- a/src/test/java/nablarch/common/web/tag/DownloadButtonTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/DownloadButtonTagTest.java
@@ -1,16 +1,18 @@
 package nablarch.common.web.tag;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.List;
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
-
+import nablarch.fw.web.handler.SecureHandler;
 import org.junit.Test;
 
 /**
@@ -60,6 +62,50 @@ public class DownloadButtonTagTest extends TagTestSupport<DownloadButtonTag> {
     }
 
     /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接buttonタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // button
+        target.setName("name_test");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] button[name='name_test']\").onclick = window.nablarch_submit;"));
+    }
+
+    /**
      * サロゲートペアを扱うテストケース。
      * @throws Exception
      */
@@ -99,6 +145,279 @@ public class DownloadButtonTagTest extends TagTestSupport<DownloadButtonTag> {
         assertThat(info.getName(), is("🙊🙊🙊"));
         assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
         assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // button
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\""
+                , "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\""
+                , "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\""
+                , "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\""
+                , "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // button
+        target.setName("name_test");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // input
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
     }
 
     /**

--- a/src/test/java/nablarch/common/web/tag/DownloadLinkTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/DownloadLinkTagTest.java
@@ -1,16 +1,18 @@
 package nablarch.common.web.tag;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.List;
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
-
+import nablarch.fw.web.handler.SecureHandler;
 import org.junit.Test;
 
 /**
@@ -57,6 +59,47 @@ public class DownloadLinkTagTest extends TagTestSupport<DownloadLinkTag> {
     }
 
     /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接aタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // a
+        target.setName("name_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] a[name='name_test']\").onclick = window.nablarch_submit;"));
+    }
+
+    /**
      * サロゲートペアを扱うテストケース。
      * @throws Exception
      */
@@ -95,6 +138,270 @@ public class DownloadLinkTagTest extends TagTestSupport<DownloadLinkTag> {
         assertThat(info.getName(), is("🙊🙊🙊"));
         assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
         assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setName("name_test");
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // a
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
     }
 
     /**

--- a/src/test/java/nablarch/common/web/tag/DownloadSubmitTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/DownloadSubmitTagTest.java
@@ -1,17 +1,19 @@
 package nablarch.common.web.tag;
 
+import java.util.List;
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
-
+import nablarch.fw.web.handler.SecureHandler;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -75,6 +77,59 @@ public class DownloadSubmitTagTest extends TagTestSupport<DownloadSubmitTag> {
     }
 
     /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接inputタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // input
+        target.setName("name_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+
+        target.setSrc("download_src_value");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<input",
+                "type=\"submit\"",
+                "name=\"name_test\"",
+                "value=\"value_test\"",
+                "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] input[name='name_test']\").onclick = window.nablarch_submit;"));
+    }
+
+    /**
      * サロゲートペアを扱うテストケース。
      * @throws Exception
      */
@@ -121,6 +176,315 @@ public class DownloadSubmitTagTest extends TagTestSupport<DownloadSubmitTag> {
         assertThat(info.getName(), is("😸😸😸"));
         assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
         assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+
+        target.setSrc("download_src_value");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));        // スクリプトは生成されない
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));        // スクリプトは生成されない
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));        // スクリプトは生成されない
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));        // スクリプトは生成されない
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setName("name_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+
+        target.setSrc("download_src_value");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // input
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"download_src_value" + "?nablarch_static_content_version=1.0.0" + '"',
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.DOWNLOAD));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
     }
 
     /**

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -1,18 +1,24 @@
 package nablarch.common.web.tag;
 
 import static nablarch.fw.ExecutionContext.FW_PREFIX;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.matchers.JUnitMatchers.containsString;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import nablarch.common.web.WebConfig;
@@ -23,7 +29,7 @@ import nablarch.common.web.hiddenencryption.HiddenEncryptionUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
 import nablarch.fw.web.handler.KeitaiAccessHandler;
-
+import nablarch.fw.web.handler.SecureHandler;
 import nablarch.test.support.web.servlet.MockServletRequest;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +51,10 @@ public class FormTagTest extends TagTestSupport<FormTag> {
 
             // サブミット時に呼ばれる関数
             "function $fwPrefix$submit(event, element) {",
+            "    if (element == null) {",
+            "        element = event.currentTarget;",
+            "    }",
+
             "    var isAnchor = element.tagName.match(/a/i);",
 
                  // formタグを取得する。
@@ -239,6 +249,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        pageContext = new MockPageContext(true);
         target.setPageContext(pageContext);
         TagUtil.getCustomTagConfig().setUseHiddenEncryption(false);
     }
@@ -481,7 +492,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
                 "<!--",
                 SUBMISSION_END_MARK_PREFIX + ".name_test" + TagTestUtil.ESC_HTML + " = true;",
                 "-->",
-                "</script>").split(Builder.LS);;
+                "</script>").split(Builder.LS);
         for (int i = 0; i < splitActual.length; i++) {
             TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
         }
@@ -519,7 +530,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
                 "<!--",
                 SUBMISSION_END_MARK_PREFIX + ".nablarch_form1 = true;",
                 "-->",
-                "</script>").split(Builder.LS);;
+                "</script>").split(Builder.LS);
         for (int i = 0; i < splitActual.length; i++) {
             TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
         }
@@ -1761,14 +1772,14 @@ public class FormTagTest extends TagTestSupport<FormTag> {
                 "<!--",
                 SUBMISSION_END_MARK_PREFIX + ".nablarch_form1 = true;",
                 "-->",
-                "</script>").split(Builder.LS);;
+                "</script>").split(Builder.LS);
         for (int i = 0; i < splitActual.length; i++) {
             TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
         }
 
         // autocompleteDisableTarget = "password"の場合
 
-        pageContext = new MockPageContext();
+        pageContext = new MockPageContext(true);
         target = new FormTag();
         target.setPageContext(pageContext);
         TagUtil.getCustomTagConfig().setAutocompleteDisableTarget("password");
@@ -1802,7 +1813,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
                 "<!--",
                 SUBMISSION_END_MARK_PREFIX + ".nablarch_form1 = true;",
                 "-->",
-                "</script>").split(Builder.LS);;
+                "</script>").split(Builder.LS);
         for (int i = 0; i < splitActual.length; i++) {
             TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
         }
@@ -1897,7 +1908,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
                 "<!--",
                 SUBMISSION_END_MARK_PREFIX + ".nablarch_form1 = true;",
                 "-->",
-                "</script>").split(Builder.LS);;
+                "</script>").split(Builder.LS);
         for (int i = 0; i < splitActual.length; i++) {
             TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
         }
@@ -1942,7 +1953,7 @@ public class FormTagTest extends TagTestSupport<FormTag> {
                 "<!--",
                 SUBMISSION_END_MARK_PREFIX + ".nablarch_form1 = true;",
                 "-->",
-                "</script>").split(Builder.LS);;
+                "</script>").split(Builder.LS);
         for (int i = 0; i < splitActual.length; i++) {
             TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
         }
@@ -2315,9 +2326,420 @@ public class FormTagTest extends TagTestSupport<FormTag> {
                 "<!--",
                 SUBMISSION_END_MARK_PREFIX + ".nablarch_form1 = true;",
                 "-->",
-                "</script>").split(Builder.LS);;
+                "</script>").split(Builder.LS);
         for (int i = 0; i < splitActual.length; i++) {
             TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
         }
+    }
+
+    /**
+     * nonceを設定しない状態でformタグ（複数含む）を構築すると、子要素になっているイベントハンドラが
+     * 生成するJavaScriptが対象のタグの属性に直接書き出されることを確認する。
+     */
+    @Test
+    public void testMultipleFormsScriptsNoNonce() throws Exception {
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        target.setName("my_form1");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+
+        assertTagOutputAndClearOutput(
+                "",
+                // nonceなし
+                "<script type=\"text/javascript\">",
+                "<!--",
+                SUBMIT_FUNCTION,
+                "-->",
+                "</script>",
+                "<form name=\"my_form1\" method=\"post\">"
+        );
+
+        // form1内のコントロール（button, submit, linkのパターンを網羅）
+        ButtonTag buttonTag1 = new ButtonTag();
+        buttonTag1.setPageContext(pageContext);
+        buttonTag1.setName("my_form1_button1");
+        buttonTag1.setUri("./my_form1_button1");
+        buttonTag1.doStartTag();
+        buttonTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                // onclickイベントハンドラが直接設定される
+                "<button name=\"my_form1_button1\" onclick=\"return window.nablarch_submit(event, this);\"></button>"
+        );
+
+        PopupSubmitTag popupSubmitTag1 = new PopupSubmitTag();
+        popupSubmitTag1.setPageContext(pageContext);
+        popupSubmitTag1.setName("my_form1_popup_submit1");
+        popupSubmitTag1.setUri("./my_form1_popup_submit1");
+        popupSubmitTag1.doStartTag();
+        popupSubmitTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                // onclickイベントハンドラが直接設定される
+                "<input name=\"my_form1_popup_submit1\" onclick=\"return window.nablarch_submit(event, this);\" />"
+        );
+
+        DownloadLinkTag downloadLinkTag1 = new DownloadLinkTag();
+        downloadLinkTag1.setPageContext(pageContext);
+        downloadLinkTag1.setName("my_form1_download_link1");
+        downloadLinkTag1.setUri("./my_form1_download_link1");
+        downloadLinkTag1.doStartTag();
+        downloadLinkTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                // onclickイベントハンドラが直接設定される
+                "<a name=\"my_form1_download_link1\" href=\"./my_form1_download_link1_encode_suffix\" onclick=\"return window.nablarch_submit(event, this);\"></a>"
+        );
+
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        Set<Integer> skipIndices = new HashSet<Integer>();
+        skipIndices.add(1);
+
+        // nablarch_hiddenの中身をアサーション（HashMapにより構築されているので順序が安定しないため）
+        String output = TagTestUtil.getOutput(pageContext);
+        String nablarchHiddenActual = output.split(TagUtil.getCustomTagConfig().getLineSeparator())[1];
+        Pattern nablarchHiddenPattern = Pattern.compile("<input type=\"hidden\" name=\"nablarch_hidden\" value=\"(.+)\" />");
+        Matcher m = nablarchHiddenPattern.matcher(nablarchHiddenActual);
+
+        assertThat(m.find(), is(true));
+        assertThat(
+                Arrays.asList(m.group(1).split("\\|")),
+                containsInAnyOrder("nablarch_hidden_submit_my_form1_button1=", "nablarch_hidden_submit_my_form1_download_link1=", "nablarch_hidden_submit_my_form1_popup_submit1=")
+        );
+
+        assertTagOutputAndClearOutput(
+                skipIndices,
+                "",
+                // nablarch_hiddenは順序が安定しないのでここではスキップ
+                "** nablarch_hiddenは前段で正規表現にて確認 **",
+                "<input type=\"hidden\" name=\"nablarch_submit\" value=\"\" />",
+                "<script type=\"text/javascript\">",
+                "<!--",
+                "nablarch_submission_info.my_form1 = {",
+                "\"my_form1_button1\": { \"action\": \"./my_form1_button1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"TRANSITION\" },",
+                "\"my_form1_popup_submit1\": { \"action\": \"./my_form1_popup_submit1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"POPUP\", \"popupWindowName\": null, \"popupOption\": \"\", \"changeParamNames\": {} },",
+                "\"my_form1_download_link1\": { \"action\": \"./my_form1_download_link1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"DOWNLOAD\", \"changeParamNames\": {} }",
+                "};",
+                "-->",
+                "</script>",
+                "</form>",
+                // nonceなし
+                "<script type=\"text/javascript\">",
+                "<!--",
+                "nablarch_submission_info.endMark.my_form1 = true;",
+                "-->",
+                "</script>"
+        );
+
+        // form 2つ目
+        FormTag formTag2 = new FormTag();
+        formTag2.setPageContext(pageContext);
+
+        formTag2.setName("my_form2");
+
+        assertThat(formTag2.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+
+        assertTagOutputAndClearOutput(
+                "",
+                "<form name=\"my_form2\" method=\"post\">"
+        );
+
+        // form2内のコントロール（button, submit, linkのパターンを網羅）
+        SubmitTag submitTag1 = new SubmitTag();
+        submitTag1.setPageContext(pageContext);
+        submitTag1.setName("my_form2_submit1");
+        submitTag1.setUri("./my_form2_submit1");
+        submitTag1.doStartTag();
+        submitTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                // onclickイベントハンドラが直接設定される
+                "<input name=\"my_form2_submit1\" onclick=\"return window.nablarch_submit(event, this);\" />"
+        );
+
+        PopupLinkTag popupLinkTag1 = new PopupLinkTag();
+        popupLinkTag1.setPageContext(pageContext);
+        popupLinkTag1.setName("my_form2_popup_link1");
+        popupLinkTag1.setUri("./my_form2_popup_link1");
+        popupLinkTag1.doStartTag();
+        popupLinkTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                // onclickイベントハンドラが直接設定される
+                "<a name=\"my_form2_popup_link1\" href=\"./my_form2_popup_link1_encode_suffix\" onclick=\"return window.nablarch_submit(event, this);\"></a>"
+        );
+
+        DownloadButtonTag downloadButtonTag1 = new DownloadButtonTag();
+        downloadButtonTag1.setPageContext(pageContext);
+        downloadButtonTag1.setName("my_form2_download_button1");
+        downloadButtonTag1.setUri("./my_form2_download_button1");
+        downloadButtonTag1.doStartTag();
+        downloadLinkTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                // onclickイベントハンドラが直接設定される
+                "<button name=\"my_form2_download_button1\" onclick=\"return window.nablarch_submit(event, this);\"></a>"
+        );
+
+        assertThat(formTag2.doEndTag(), is(Tag.EVAL_PAGE));
+
+        // nablarch_hiddenの中身をアサーション（HashMapにより構築されているので順序が安定しないため）
+        output = TagTestUtil.getOutput(pageContext);
+        nablarchHiddenActual = output.split(TagUtil.getCustomTagConfig().getLineSeparator())[1];
+        nablarchHiddenPattern = Pattern.compile("<input type=\"hidden\" name=\"nablarch_hidden\" value=\"(.+)\" />");
+        m = nablarchHiddenPattern.matcher(nablarchHiddenActual);
+
+        assertThat(m.find(), is(true));
+        assertThat(
+                Arrays.asList(m.group(1).split("\\|")),
+                containsInAnyOrder("nablarch_hidden_submit_my_form2_download_button1=", "nablarch_hidden_submit_my_form2_popup_link1=", "nablarch_hidden_submit_my_form2_submit1=")
+        );
+
+        assertTagOutputAndClearOutput(
+                skipIndices,
+                "",
+                // nablarch_hiddenは順序が安定しないのでここではスキップ
+                "** nablarch_hiddenは前段で正規表現にて確認 **",
+                "<input type=\"hidden\" name=\"nablarch_submit\" value=\"\" />",
+                "<script type=\"text/javascript\">",
+                "<!--",
+                "nablarch_submission_info.my_form2 = {",
+                "\"my_form2_submit1\": { \"action\": \"./my_form2_submit1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"TRANSITION\" },",
+                "\"my_form2_popup_link1\": { \"action\": \"./my_form2_popup_link1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"POPUP\", \"popupWindowName\": null, \"popupOption\": \"\", \"changeParamNames\": {} },",
+                "\"my_form2_download_button1\": { \"action\": \"./my_form2_download_button1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"DOWNLOAD\", \"changeParamNames\": {} }",
+                "};",
+                "-->",
+                "</script>",
+                "</form>",
+                // nonceなし
+                "<script type=\"text/javascript\">",
+                "<!--",
+                "nablarch_submission_info.endMark.my_form2 = true;",
+                "-->",
+                "</script>"
+        );
+    }
+
+    /**
+     * nonceを設定した状態でformタグ（複数含む）を構築すると、子要素になっているイベントハンドラが
+     * 生成するJavaScriptがscriptタグ内に書き出されることを確認する。
+     */
+    @Test
+    public void testMultipleFormsScriptsHasNonce() throws Exception {
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        String nonce = "abcde";
+
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, nonce);
+
+        target.setName("my_form1");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+
+        assertTagOutputAndClearOutput(
+                "",
+                // nonceが付与されている
+                "<script type=\"text/javascript\" nonce=\"" + nonce + "\">",
+                "<!--",
+                SUBMIT_FUNCTION,
+                "-->",
+                "</script>",
+                "<form name=\"my_form1\" method=\"post\">"
+        );
+
+        // form1内のコントロール（button, submit, linkのパターンを網羅）
+        ButtonTag buttonTag1 = new ButtonTag();
+        buttonTag1.setPageContext(pageContext);
+        buttonTag1.setName("my_form1_button1");
+        buttonTag1.setUri("./my_form1_button1");
+        buttonTag1.doStartTag();
+        buttonTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                "<button name=\"my_form1_button1\"></button>"
+        );
+
+        PopupSubmitTag popupSubmitTag1 = new PopupSubmitTag();
+        popupSubmitTag1.setPageContext(pageContext);
+        popupSubmitTag1.setName("my_form1_popup_submit1");
+        popupSubmitTag1.setUri("./my_form1_popup_submit1");
+        popupSubmitTag1.doStartTag();
+        popupSubmitTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                "<input name=\"my_form1_popup_submit1\" />"
+        );
+
+        DownloadLinkTag downloadLinkTag1 = new DownloadLinkTag();
+        downloadLinkTag1.setPageContext(pageContext);
+        downloadLinkTag1.setName("my_form1_download_link1");
+        downloadLinkTag1.setUri("./my_form1_download_link1");
+        downloadLinkTag1.doStartTag();
+        downloadLinkTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                "<a name=\"my_form1_download_link1\" href=\"./my_form1_download_link1_encode_suffix\"></a>"
+        );
+
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        Set<Integer> skipIndices = new HashSet<Integer>();
+        skipIndices.add(1);
+
+        // nablarch_hiddenの中身をアサーション（HashMapにより構築されているので順序が安定しないため）
+        String output = TagTestUtil.getOutput(pageContext);
+        String nablarchHiddenActual = output.split(TagUtil.getCustomTagConfig().getLineSeparator())[1];
+        Pattern nablarchHiddenPattern = Pattern.compile("<input type=\"hidden\" name=\"nablarch_hidden\" value=\"(.+)\" />");
+        Matcher m = nablarchHiddenPattern.matcher(nablarchHiddenActual);
+
+        assertTagOutputAndClearOutput(
+                skipIndices,
+                "",
+                // nablarch_hiddenは順序が安定しないのでここではスキップ
+                "** nablarch_hiddenは前段で正規表現にて確認 **",
+                "<input type=\"hidden\" name=\"nablarch_submit\" value=\"\" />",
+                "<script type=\"text/javascript\" nonce=\"" + nonce + "\">",
+                "<!--",
+                "",
+                // formの要素に対するイベントハンドラ
+                "document.querySelector(\"form[name='my_form1'] button[name='my_form1_button1']\").onclick = window.nablarch_submit;",
+                "document.querySelector(\"form[name='my_form1'] input[name='my_form1_popup_submit1']\").onclick = window.nablarch_submit;",
+                "document.querySelector(\"form[name='my_form1'] a[name='my_form1_download_link1']\").onclick = window.nablarch_submit;",
+                "",
+                "nablarch_submission_info.my_form1 = {",
+                "\"my_form1_button1\": { \"action\": \"./my_form1_button1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"TRANSITION\" },",
+                "\"my_form1_popup_submit1\": { \"action\": \"./my_form1_popup_submit1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"POPUP\", \"popupWindowName\": null, \"popupOption\": \"\", \"changeParamNames\": {} },",
+                "\"my_form1_download_link1\": { \"action\": \"./my_form1_download_link1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"DOWNLOAD\", \"changeParamNames\": {} }",
+                "};",
+                "-->",
+                "</script>",
+                "</form>",
+                // nonceが付与されている
+                "<script type=\"text/javascript\" nonce=\"" + nonce + "\">",
+                "<!--",
+                "nablarch_submission_info.endMark.my_form1 = true;",
+                "-->",
+                "</script>"
+        );
+
+        // form 2つ目
+        FormTag formTag2 = new FormTag();
+        formTag2.setPageContext(pageContext);
+
+        formTag2.setName("my_form2");
+
+        assertThat(formTag2.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+
+        assertTagOutputAndClearOutput(
+                "",
+                "<form name=\"my_form2\" method=\"post\">"
+        );
+
+        // form2内のコントロール（button, submit, linkのパターンを網羅）
+        SubmitTag submitTag1 = new SubmitTag();
+        submitTag1.setPageContext(pageContext);
+        submitTag1.setName("my_form2_submit1");
+        submitTag1.setUri("./my_form2_submit1");
+        submitTag1.doStartTag();
+        submitTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                "<input name=\"my_form2_submit1\" />"
+        );
+
+        PopupLinkTag popupLinkTag1 = new PopupLinkTag();
+        popupLinkTag1.setPageContext(pageContext);
+        popupLinkTag1.setName("my_form2_popup_link1");
+        popupLinkTag1.setUri("./my_form2_popup_link1");
+        popupLinkTag1.doStartTag();
+        popupLinkTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                "<a name=\"my_form2_popup_link1\" href=\"./my_form2_popup_link1_encode_suffix\"></a>"
+        );
+
+        DownloadButtonTag downloadButtonTag1 = new DownloadButtonTag();
+        downloadButtonTag1.setPageContext(pageContext);
+        downloadButtonTag1.setName("my_form2_download_button1");
+        downloadButtonTag1.setUri("./my_form2_download_button1");
+        downloadButtonTag1.doStartTag();
+        downloadLinkTag1.doEndTag();
+
+        assertTagOutputAndClearOutput(
+                "<button name=\"my_form2_download_button1\"></a>"
+        );
+
+        assertThat(formTag2.doEndTag(), is(Tag.EVAL_PAGE));
+
+        // nablarch_hiddenの中身をアサーション（HashMapにより構築されているので順序が安定しないため）
+        output = TagTestUtil.getOutput(pageContext);
+        nablarchHiddenActual = output.split(TagUtil.getCustomTagConfig().getLineSeparator())[1];
+        nablarchHiddenPattern = Pattern.compile("<input type=\"hidden\" name=\"nablarch_hidden\" value=\"(.+)\" />");
+        m = nablarchHiddenPattern.matcher(nablarchHiddenActual);
+
+        assertThat(m.find(), is(true));
+        assertThat(
+                Arrays.asList(m.group(1).split("\\|")),
+                containsInAnyOrder("nablarch_hidden_submit_my_form2_download_button1=", "nablarch_hidden_submit_my_form2_popup_link1=", "nablarch_hidden_submit_my_form2_submit1=")
+        );
+
+        assertTagOutputAndClearOutput(
+                skipIndices,
+                "",
+                // nablarch_hiddenは順序が安定しないのでここではスキップ
+                "** nablarch_hiddenは前段で正規表現にて確認 **",
+                "<input type=\"hidden\" name=\"nablarch_submit\" value=\"\" />",
+                "<script type=\"text/javascript\" nonce=\"" + nonce + "\">",
+                "<!--",
+                "",
+                // formの要素に対するイベントハンドラ
+                "document.querySelector(\"form[name='my_form2'] input[name='my_form2_submit1']\").onclick = window.nablarch_submit;",
+                "document.querySelector(\"form[name='my_form2'] a[name='my_form2_popup_link1']\").onclick = window.nablarch_submit;",
+                "document.querySelector(\"form[name='my_form2'] button[name='my_form2_download_button1']\").onclick = window.nablarch_submit;",
+                "",
+                "nablarch_submission_info.my_form2 = {",
+                "\"my_form2_submit1\": { \"action\": \"./my_form2_submit1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"TRANSITION\" },",
+                "\"my_form2_popup_link1\": { \"action\": \"./my_form2_popup_link1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"POPUP\", \"popupWindowName\": null, \"popupOption\": \"\", \"changeParamNames\": {} },",
+                "\"my_form2_download_button1\": { \"action\": \"./my_form2_download_button1_encode_suffix\", \"allowDoubleSubmission\": true, \"submissionAction\": \"DOWNLOAD\", \"changeParamNames\": {} }",
+                "};",
+                "-->",
+                "</script>",
+                "</form>",
+                // nonceが付与されている
+                "<script type=\"text/javascript\" nonce=\"" + nonce + "\">",
+                "<!--",
+                "nablarch_submission_info.endMark.my_form2 = true;",
+                "-->",
+                "</script>"
+        );
+    }
+
+    private void assertTagOutputAndClearOutput(String... expectedArray) {
+        assertTagOutputAndClearOutput(Collections.<Integer>emptySet(), expectedArray);
+    }
+
+    private void assertTagOutputAndClearOutput(Set<Integer> skipIndices, String... expectedArray) {
+        String ls = TagUtil.getCustomTagConfig().getLineSeparator();
+        String actual = TagTestUtil.getOutput(pageContext);
+        String[] splitActual = actual.split(ls);
+        String[] splitExpected = Builder.lines(expectedArray).split(Builder.LS);
+
+        for (int i = 0; i < splitActual.length; i++) {
+            if (skipIndices.contains(i)) {
+                // equalsで比較できないものはスキップ
+                continue;
+            }
+
+            TagTestUtil.assertTag(splitActual[i], splitExpected[i], " ");
+        }
+
+        assertThat(splitActual.length, is(splitExpected.length));
+
+        TagTestUtil.clearOutput(pageContext);
     }
 }

--- a/src/test/java/nablarch/common/web/tag/PopupButtonTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/PopupButtonTagTest.java
@@ -3,14 +3,17 @@ package nablarch.common.web.tag;
 import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
+import nablarch.fw.web.handler.SecureHandler;
 import org.junit.Test;
 
+import java.util.List;
 import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class PopupButtonTagTest extends TagTestSupport<PopupButtonTag> {
@@ -18,13 +21,13 @@ public class PopupButtonTagTest extends TagTestSupport<PopupButtonTag> {
     public PopupButtonTagTest() {
         super(new PopupButtonTag());
     }
-    
+
     @Test
     public void testInputPageForDefault() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);
-        
+
         // button
         target.setName("name_test");
 
@@ -36,21 +39,21 @@ public class PopupButtonTagTest extends TagTestSupport<PopupButtonTag> {
         // nablarch
         target.setUri("./R12345");
         target.setPopupOption("width=400, height=300");
-        
+
         assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
         assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
-        
+
         String actual = TagTestUtil.getOutput(pageContext);
         String expected = Builder.lines(
                 "<button",
                 "name=\"name_test\"",
                 "onclick=\"return window.nablarch_submit(event, this);\"",
                 "autofocus=\"autofocus\"></button>"
-                ).replace(Builder.LS, " ");
+        ).replace(Builder.LS, " ");
         TagTestUtil.assertTag(actual, expected, " ");
 
         assertFalse(formContext.getInputNames().contains("name_test"));
-        
+
         assertThat(formContext.getSubmissionInfoList().size(), is(1));
         SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
         assertThat(info.getName(), is("name_test"));
@@ -58,6 +61,55 @@ public class PopupButtonTagTest extends TagTestSupport<PopupButtonTag> {
         assertThat(info.isAllowDoubleSubmission(), is(true));
         assertThat(info.getAction(), is(SubmissionAction.POPUP));
         assertThat(info.getPopupOption(), is("width=400, height=300"));
+    }
+
+    /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接buttonタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // button
+        target.setName("name_test");
+
+        target.setPopupWindowName("popup");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] button[name='name_test']\").onclick = window.nablarch_submit;"));
     }
 
     /**
@@ -148,7 +200,303 @@ public class PopupButtonTagTest extends TagTestSupport<PopupButtonTag> {
         assertThat(info.getAction(), is(SubmissionAction.POPUP));
         assertThat(info.getPopupOption(), is("width=500, height=400"));
     }
-    
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // button
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        target.setPopupWindowName("popup");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // button
+        target.setName("name_test");
+
+        target.setPopupWindowName("popup");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+               TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // button
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // button
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<button",
+                "name=\"name_test\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\"></button>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
     /**
      * 本タグがFormタグ内に定義されていない場合（FormContextが設定されていない場合）に、
      * IllegalStateExceptionがスローされることのテスト。

--- a/src/test/java/nablarch/common/web/tag/PopupLinkTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/PopupLinkTagTest.java
@@ -3,14 +3,17 @@ package nablarch.common.web.tag;
 import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
+import nablarch.fw.web.handler.SecureHandler;
 import org.junit.Test;
 
+import java.util.List;
 import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -58,6 +61,52 @@ public class PopupLinkTagTest extends TagTestSupport<PopupLinkTag> {
         assertThat(info.isAllowDoubleSubmission(), is(true));
         assertThat(info.getAction(), is(SubmissionAction.POPUP));
         assertThat(info.getPopupOption(), is("width=400, height=300"));
+    }
+
+    /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接aタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // a
+        target.setName("name_test");
+
+        target.setPopupWindowName("popup");
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] a[name='name_test']\").onclick = window.nablarch_submit;"));
     }
 
     /**
@@ -163,6 +212,295 @@ public class PopupLinkTagTest extends TagTestSupport<PopupLinkTag> {
         assertThat(info.getAction(), is(SubmissionAction.POPUP));
         // デフォルトのwindowOptionが設定されていること。
         assertThat(info.getPopupOption(), is("width=500, height=400"));
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        target.setPopupWindowName("popup");
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setName("name_test");
+
+        target.setPopupWindowName("popup");
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // a
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
     }
 
     /**

--- a/src/test/java/nablarch/common/web/tag/PopupSubmitTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/PopupSubmitTagTest.java
@@ -1,17 +1,19 @@
 package nablarch.common.web.tag;
 
+import java.util.List;
 import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.util.Builder;
-
+import nablarch.fw.web.handler.SecureHandler;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class PopupSubmitTagTest extends TagTestSupport<PopupSubmitTag> {
@@ -69,6 +71,62 @@ public class PopupSubmitTagTest extends TagTestSupport<PopupSubmitTag> {
     }
 
     /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接inputタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // input
+        target.setName("name_test");
+        target.setPopupWindowName("window_name");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+        target.setSrc("src_value");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] input[name='name_test']\").onclick = window.nablarch_submit;"));
+    }
+
+    /**
      * サロゲートペアを扱うテストケース
      * @throws Exception
      */
@@ -118,6 +176,347 @@ public class PopupSubmitTagTest extends TagTestSupport<PopupSubmitTag> {
         assertThat(info.isAllowDoubleSubmission(), is(true));
         assertThat(info.getAction(), is(SubmissionAction.POPUP));
         assertThat(info.getPopupOption(), is("width=400, height=300"));
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setName("name_test");
+        target.setPopupWindowName("window_name");
+        target.setOnclick("onclick_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+        target.setSrc("src_value");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<input",
+                "type=\"submit\"",
+                "name=\"name_test\"",
+                "value=\"value_test\"",
+                "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                "onclick=\"onclick_test\"",
+                "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // CSP対応用のnonceを含めている場合
+
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // suppressDefaultSubmitをtrueにした場合
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // suppressDefaultSubmitをtrueにした場合（CSP）
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // input
+        target.setName("name_test");
+        target.setPopupWindowName("window_name");
+        target.setOnclick("onclick_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+        target.setSrc("src_value");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setName("name_test");
+        target.setPopupWindowName("window_name");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+        target.setSrc("src_value");
+
+        // HTML5
+        target.setAutofocus(true);
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setPopupOption("width=400, height=300");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // CSP対応用のnonceを含めている場合
+
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // onclickを指定した場合はそのまま出力される
+
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // onclickを指定した場合はそのまま出力される（CSP）
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "src=\"src_value?nablarch_static_content_version=1.0.0\"",
+                        "onclick=\"onclick_test\"",
+                        "autofocus=\"autofocus\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.isAllowDoubleSubmission(), is(true));
+        assertThat(info.getAction(), is(SubmissionAction.POPUP));
+        assertThat(info.getPopupOption(), is("width=400, height=300"));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
     }
 
     /**

--- a/src/test/java/nablarch/common/web/tag/SubmitLinkTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/SubmitLinkTagTest.java
@@ -1,12 +1,13 @@
 package nablarch.common.web.tag;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -16,6 +17,7 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.BodyTag;
 import jakarta.servlet.jsp.tagext.Tag;
 
@@ -27,7 +29,7 @@ import nablarch.common.web.handler.WebTestUtil;
 import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.Builder;
-
+import nablarch.fw.web.handler.SecureHandler;
 import org.junit.Test;
 
 /**
@@ -228,6 +230,48 @@ public class SubmitLinkTagTest extends TagTestSupport<SubmitLinkTag> {
         assertThat(info.getName(), is("name_test"));
         assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
         assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+    }
+
+    /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接aタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // a
+        target.setName("name_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+                ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        assertThat(formContext.getInlineSubmissionScripts().size(), is(1));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] a[name='name_test']\").onclick = window.nablarch_submit;"));
+
     }
 
     /**
@@ -624,6 +668,270 @@ public class SubmitLinkTagTest extends TagTestSupport<SubmitLinkTag> {
         expected = "";
         TagTestUtil.assertTag(actual, expected, " ");
         TagTestUtil.clearOutput(pageContext);
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* suppressDefaultSubmitをtrueにした場合（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setName("name_test");
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* CSP対応用のnonceを含めている場合 */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // a
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* onclickを指定した場合はそのまま出力される（CSP対応用のnonceを含めている） */
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                "<a",
+                "name=\"name_test\"",
+                "href=\"./R12345" + WebTestUtil.ENCODE_URL_SUFFIX + "\"",
+                "onclick=\"onclick_test\"></a>"
+        ).replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
     }
 
     /**

--- a/src/test/java/nablarch/common/web/tag/SubmitTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/SubmitTagTest.java
@@ -8,18 +8,21 @@ import nablarch.common.web.tag.SubmissionInfo.SubmissionAction;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.Builder;
 import nablarch.fw.web.handler.KeitaiAccessHandler;
+import nablarch.fw.web.handler.SecureHandler;
 import nablarch.test.support.web.servlet.MockServletRequest;
 import org.junit.Test;
 
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
+
+import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -252,6 +255,52 @@ public class SubmitTagTest extends TagTestSupport<SubmitTag> {
     }
 
     /**
+     * CSP対応用のnonceをリクエストスコープに保存した時に、スクリプトが直接inputタグのonclick属性に
+     * 出力されるのではなく、フォームコンテキストにためこまれることを確認する
+     */
+    @Test
+    public void testInputPageForHasCspNonce() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // input
+        target.setName("name_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] input[name='name_test']\").onclick = window.nablarch_submit;"));
+    }
+
+    /**
      * サロゲートペアを扱うテストケース
      *
      * @throws Exception
@@ -446,6 +495,288 @@ public class SubmitTagTest extends TagTestSupport<SubmitTag> {
         assertThat(info.getName(), is("name_test"));
         assertThat(info.getUri(), is("http://nablarch.co.jp" + WebTestUtil.CONTEXT_PATH + "/R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
         assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+    }
+
+    /**
+     * onclick属性を指定した時に、CSPのnonceの有無に関わらず指定した属性値がそのまま出力されることを確認する。
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInputPageForOnclick() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setName("name_test");
+        target.setOnclick("onclick_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+
+        // nablarch
+        target.setUri("./R12345");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "onclick=\"onclick_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + nablarch.test.support.web.WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // CSP対応用のnonceを含めている場合
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "onclick=\"onclick_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + nablarch.test.support.web.WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは登録されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // suppressDefaultSubmitをtrueにした場合
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "onclick=\"onclick_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + nablarch.test.support.web.WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは登録されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // suppressDefaultSubmitをtrueにした場合（CSP）
+
+        TagTestUtil.clearOutput(pageContext);
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // nablarch
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "onclick=\"onclick_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + nablarch.test.support.web.WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは登録されない
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+    }
+
+    /**
+     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * サブミット用のスクリプトが出力されなくなることを確認する。
+     */
+    @Test
+    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+        TagTestUtil.setUpDefaultConfig();
+        FormContext formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setName("name_test");
+
+        // submit,button,image
+        target.setType("submit");
+        target.setValue("value_test");
+
+        // nablarch
+        target.setUri("./R12345");
+        target.setSuppressDefaultSubmit(true);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        String actual = TagTestUtil.getOutput(pageContext);
+        String expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        SubmissionInfo info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInputNames().isEmpty(), is(true));
+
+        // CSP対応用のnonceを含めている場合
+
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInputNames().isEmpty(), is(true));
+
+        // onclickを指定した場合はそのまま出力される
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+
+        // input
+        target.setOnclick("onclick_test");
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "onclick=\"onclick_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInputNames().isEmpty(), is(true));
+
+        // onclickを指定した場合はそのまま出力される（CSP）
+        TagTestUtil.clearOutput(pageContext);
+        TagTestUtil.setUpDefaultConfig();
+        formContext = TagTestUtil.createFormContext();
+        TagUtil.setFormContext(pageContext, formContext);
+        // nonce
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        assertThat(target.doStartTag(), is(Tag.EVAL_BODY_INCLUDE));
+        assertThat(target.doEndTag(), is(Tag.EVAL_PAGE));
+
+        actual = TagTestUtil.getOutput(pageContext);
+        expected = Builder.lines(
+                        "<input",
+                        "type=\"submit\"",
+                        "name=\"name_test\"",
+                        "value=\"value_test\"",
+                        "onclick=\"onclick_test\" />")
+                .replace(Builder.LS, " ");
+        TagTestUtil.assertTag(actual, expected, " ");
+
+        assertFalse(formContext.getInputNames().contains("name_test"));
+
+        assertThat(formContext.getSubmissionInfoList().size(), is(1));
+        info = formContext.getSubmissionInfoList().get(0);
+        assertThat(info.getName(), is("name_test"));
+        assertThat(info.getUri(), is("./R12345" + WebTestUtil.ENCODE_URL_SUFFIX));
+        assertThat(info.getAction(), is(SubmissionAction.TRANSITION));
+        // スクリプトは生成されない
+        assertThat(formContext.getInputNames().isEmpty(), is(true));
     }
 
     @Test

--- a/src/test/java/nablarch/common/web/tag/TagTestUtil.java
+++ b/src/test/java/nablarch/common/web/tag/TagTestUtil.java
@@ -31,7 +31,7 @@ import org.junit.Before;
  * @author Kiyohito Itoh
  */
 class TagTestUtil {
-
+    /** 作成した{@link nablarch.common.web.tag.FormContext}の数で、nameを自動付与する際の一部として利用する */
     private static int formCount = 0;
 
     @Before
@@ -39,13 +39,24 @@ class TagTestUtil {
     }
 
     static FormContext createFormContext() {
-        return createFormContext("post");
+        return createFormContextByMethod("post");
     }
 
-    static FormContext createFormContext(String method) {
+    static FormContext createFormContextByMethod(String method) {
+        return createFormContext(method, "test_form_name" + formCount++);
+    }
+
+    static FormContext createFormContextByName(String name) {
+        // このファクトリメソッドではformCountの値はnameに含めないが、
+        // FormContext自体は作成するのでその数を記録する意味でインクリメントしておく
+        formCount++;
+        return createFormContext("post", name);
+    }
+
+    static FormContext createFormContext(String method, String name) {
         HtmlAttributes formAttrs = new HtmlAttributes();
         formAttrs.put(HtmlAttribute.METHOD, method);
-        return new FormContext("test_form_name" + formCount++);
+        return new FormContext(name);
     }
 
     static String getOutput(PageContext pageContext) {

--- a/src/test/java/nablarch/common/web/tag/TagUtilTest.java
+++ b/src/test/java/nablarch/common/web/tag/TagUtilTest.java
@@ -1,11 +1,11 @@
 package nablarch.common.web.tag;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -36,8 +36,6 @@ import jakarta.servlet.jsp.JspWriter;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
-import org.hamcrest.Matchers;
-
 import nablarch.common.permission.BasicPermission;
 import nablarch.common.permission.Permission;
 import nablarch.common.permission.PermissionUtil;
@@ -51,13 +49,15 @@ import nablarch.core.repository.SystemRepository;
 import nablarch.core.util.Builder;
 import nablarch.core.util.FileUtil;
 import nablarch.core.util.FormatSpec;
+import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.MockHttpRequest;
+import nablarch.fw.web.handler.SecureHandler;
 import nablarch.fw.web.servlet.WebFrontController;
 import nablarch.test.support.log.app.OnMemoryLogWriter;
 import nablarch.test.support.web.servlet.MockServletContext;
 import nablarch.test.support.web.servlet.MockServletFilterConfig;
-
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1747,4 +1747,141 @@ public class TagUtilTest {
         assertThat(TagUtil.formatValue(pageContext, name, spec("decimal{#}"), "abc"), is("abc"));
     }
 
+    /**
+     * CSPのnonceがリクエストスコープに存在するか確認するテスト
+     */
+    @Test
+    public void testHasCspNonce() {
+        assertThat(TagUtil.hasCspNonce(pageContext), is(false));
+
+        String nonce = "abcde";
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, nonce, PageContext.REQUEST_SCOPE);
+
+        assertThat(TagUtil.hasCspNonce(pageContext), is(true));
+    }
+
+    /**
+     * CSPのnonceがリクエストスコープあれば取得できるか確認するテスト
+     */
+    @Test
+    public void testGetCspNonce() {
+        assertThat(TagUtil.getCspNonce(pageContext), nullValue());
+
+        String nonce = "abcde";
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, nonce, PageContext.REQUEST_SCOPE);
+
+        assertThat(TagUtil.getCspNonce(pageContext), is(nonce));
+    }
+
+    /**
+     * scriptタグを生成するテスト。CSPのnonceがリクエストスコープにあるかどうかで生成結果が変わる。
+     */
+    @Test
+    public void testCreateScriptTag() {
+        String script = "console.log('hello');";
+
+        // nonceがない場合
+        String expected = Builder.lines(
+                "<script type=\"text/javascript\">",
+                "<!--",
+                "console.log('hello');",
+                "-->",
+                "</script>"
+        );
+
+        assertThat(TagUtil.createScriptTag(pageContext, script), is(expected));
+
+        // nonceを設定した場合
+        String nonce = "abcde";
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, nonce, PageContext.REQUEST_SCOPE);
+
+        expected = Builder.lines(
+                        "<script type=\"text/javascript\" nonce=\"" + nonce + "\">",
+                        "<!--",
+                        "console.log('hello');",
+                        "-->",
+                        "</script>"
+                );
+
+        assertThat(TagUtil.createScriptTag(pageContext, script), is(expected));
+    }
+
+    @Test
+    public void testRegisterOnclickForSubmission() {
+        FormContext formContext = TagTestUtil.createFormContextByName("test_form1");
+        TagUtil.setFormContext(pageContext, formContext);
+
+        String name = "button_name1";
+
+        /* nonceなしの場合 */
+        // onclickなし、suppressDefaultSubmitはfalse
+        HtmlAttributes attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, false);
+        // デフォルトのonclick関数が設定される
+        assertThat(
+                (String) attributes.get(HtmlAttribute.ONCLICK),
+                is("return window." + ExecutionContext.FW_PREFIX + "submit(event, this);")
+        );
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // onclickあり、suppressDefaultSubmitはfalse
+        attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        attributes.put(HtmlAttribute.ONCLICK, "onclick_test");
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, false);
+        assertThat((String) attributes.get(HtmlAttribute.ONCLICK), is("onclick_test"));
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // onclickなし、suppressDefaultSubmitはtrue
+        attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, true);
+        assertThat((String) attributes.get(HtmlAttribute.ONCLICK), nullValue());
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        // onclickあり、suppressDefaultSubmitはfalse
+        attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        attributes.put(HtmlAttribute.ONCLICK, "onclick_test");
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, true);
+        assertThat((String) attributes.get(HtmlAttribute.ONCLICK), is("onclick_test"));
+        assertThat(formContext.getInlineSubmissionScripts().isEmpty(), is(true));
+
+        /* nonceありの場合 */
+        pageContext.setAttribute(SecureHandler.CSP_NONCE_KEY, "abcde", PageContext.REQUEST_SCOPE);
+
+        // onclickなし、suppressDefaultSubmitはfalse
+        attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, false);
+        assertThat((String) attributes.get(HtmlAttribute.ONCLICK), nullValue());
+        List<String> inlineSubmissionScripts = formContext.getInlineSubmissionScripts();
+        assertThat(inlineSubmissionScripts.size(), is(1));
+        // scriptタグ出力用のスクリプトが追加される
+        assertThat(inlineSubmissionScripts.get(0), is("document.querySelector(\"form[name='test_form1'] button[name='button_name1']\").onclick = window.nablarch_submit;"));
+
+        // onclickあり、suppressDefaultSubmitはfalse
+        attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        attributes.put(HtmlAttribute.ONCLICK, "onclick_test");
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, false);
+        assertThat((String) attributes.get(HtmlAttribute.ONCLICK), is("onclick_test"));
+        assertThat(formContext.getSubmissionInfoList().isEmpty(), is(true));
+
+        // onclickなし、suppressDefaultSubmitはtrue
+        attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, true);
+        assertThat((String) attributes.get(HtmlAttribute.ONCLICK), nullValue());
+        assertThat(formContext.getSubmissionInfoList().isEmpty(), is(true));
+
+        // onclickあり、suppressDefaultSubmitはfalse
+        attributes = new HtmlAttributes();
+        attributes.put(HtmlAttribute.NAME, name);
+        attributes.put(HtmlAttribute.ONCLICK, "onclick_test");
+        TagUtil.registerOnclickForSubmission(pageContext, "button", attributes, true);
+        assertThat((String) attributes.get(HtmlAttribute.ONCLICK), is("onclick_test"));
+        assertThat(formContext.getSubmissionInfoList().isEmpty(), is(true));
+    }
 }


### PR DESCRIPTION
CSP対応したdevelopをマージし、一部importをJakartaEEに対応しました。

また、`TagUtil.java`の`javaScript.append(attributes.get(HtmlAttribute.NAME));`（[該当箇所](https://github.com/nablarch/nablarch-fw-web-tag/compare/v6-develop...NAB-591/v6-web-tag#diff-f2f1aac548d75d2b3e2edae7163d858ea46af56784e2dc129641d03ce85493e7R827:~:text=javaScript.append((String)%20attributes.get(HtmlAttribute.NAME))%3B)）で、

> あいまいなメソッド呼び出し: 'StringBuilder.append(String)' と 'StringBuilder.append(StringBuffer)' が一致しています

上記のエラーが出ていたので、developと同じString型を取るようにキャストしました。