### PR TITLE
nablarch_submit関数内でEvent.currentTargetが取得できない場合にEvent.targetにフォールバックする

### DIFF
--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -777,6 +777,11 @@ public class FormTag extends GenericAttributesTagSupport {
                  // 後方互換を保つためにeventから対象の要素を取得する
             "    if (element == null) {",
             "        element = event.currentTarget;",
+                     // eventにcurrentTargetが設定されていない場合はtargetから取得する。
+                     // jQueryによるイベント発火($(...).click()など)を行った場合はこのケースになる
+            "        if (element == null) {",
+            "            element = event.target;",
+            "        }",
             "    }",
 
             "    var isAnchor = element.tagName.match(/a/i);",

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -53,6 +53,9 @@ public class FormTagTest extends TagTestSupport<FormTag> {
             "function $fwPrefix$submit(event, element) {",
             "    if (element == null) {",
             "        element = event.currentTarget;",
+            "        if (element == null) {",
+            "            element = event.target;",
+            "        }",
             "    }",
 
             "    var isAnchor = element.tagName.match(/a/i);",


### PR DESCRIPTION
#49 で、`nablarch_submit`関数に要素が渡されなかった場合、`Event`オブジェクトからイベントが発生した要素（`Event#target`）ではなくイベントハンドラが紐づけられた要素（`Event#currentTarget`）を取得するように修正したが、これによりjQueryから強制的にイベント発火しているコードが動作しなくなった。

```javascript
$(element).click();
```

この場合、イベントにハンドラに渡される`Event`オブジェクトはjQueryによりエミュレーションされたものになり、`currentTarget`プロパティを持たない。

これに対応する方法は以下の3種類。

- jQueryのイベント発火ではなく、Vanilla JavaScriptによるイベント発火に切り替える
- `nablarch_submit`関数で`Event#currentTarget`が取得できない場合に`Event#target`にフォールバックする

前者は、たとえば[Nablarch Example Webの](https://github.com/nablarch/nablarch-example-web/blob/5u24/src/main/webapp/javascripts/projectInput.js#L5-L7)以下のコードの場合

```javascript
  $("#topUpdateButton").click(function() {
    $("#bottomUpdateButton").click();
  });
```

このように書き直せば`nablarch_submit`関数を修正せずとも動作する。

```javascript
  var topUpdateButton = document.querySelector("#topUpdateButton");
  if (topUpdateButton != null) {
    topUpdateButton.onclick = function() {
        document.querySelector('#bottomUpdateButton').click();  // ここだけが重要
    };
  }
```

ただ、労力の割に得られる効果が薄く、またNablarchを使って開発するWebアプリケーションはjQueryと組み合わせて開発されることもまだ多いと考えられるためこの修正とした。

---

補足。

jQueryでイベントハンドラを扱う場合、[this](https://api.jquery.com/event.currentTarget/)が`Event#currentTarget`と同一になるがこれを`nablarch_submit`にうまく渡す方法もないので除外。  
（`Event`そのものを利用者側でカスタマイズすることになり煩雑）