### PR TITLE
EventからcurrentTargetが取得できない場合はtargetにフォールバックするよう修正

### DIFF
--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -779,6 +779,11 @@ public class FormTag extends GenericAttributesTagSupport {
                  // 後方互換を保つためにeventから対象の要素を取得する
             "    if (element == null) {",
             "        element = event.currentTarget;",
+                     // eventにcurrentTargetが設定されていない場合はtargetから取得する。
+                     // jQueryによるイベント発火($(...).click()など)を行った場合はこのケースになる
+            "        if (element == null) {",
+            "            element = event.target;",
+            "        }",
             "    }",
 
             "    var isAnchor = element.tagName.match(/a/i);",

--- a/src/test/java/nablarch/common/web/tag/FormTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/FormTagTest.java
@@ -53,6 +53,9 @@ public class FormTagTest extends TagTestSupport<FormTag> {
             "function $fwPrefix$submit(event, element) {",
             "    if (element == null) {",
             "        element = event.currentTarget;",
+            "        if (element == null) {",
+            "            element = event.target;",
+            "        }",
             "    }",
 
             "    var isAnchor = element.tagName.match(/a/i);",


### PR DESCRIPTION
#53 のv6対応版

`nablarch_submit`関数の呼び出し時に`element`が渡されていない時、`Event`の`currentTarget` → `target`プロパティの優先順位でイベントが発生した要素を取得する。