### PR TITLE
SonarQubeの静的解析への対応

### DIFF
--- a/src/main/java/nablarch/common/web/tag/ButtonTagSupport.java
+++ b/src/main/java/nablarch/common/web/tag/ButtonTagSupport.java
@@ -116,6 +116,7 @@ public abstract class ButtonTagSupport extends FocusAttributesTagSupport {
      * 認可や開閉局の状態に応じて、タグの表示方法を切り替える。切り替え方法は非表示、非活性、通常表示のいずれかである。
      * </pre>
      */
+    @Override
     public int doStartTag() throws JspException {
         checkChildElementsOfForm();
 
@@ -154,6 +155,7 @@ public abstract class ButtonTagSupport extends FocusAttributesTagSupport {
      * 閉じタグを出力する。
      * </pre>
      */
+    @Override
     public int doEndTag() throws JspException {
         DisplayMethod displayMethodResult = TagUtil.getFormContext(pageContext)
                                                    .getCurrentSubmissionInfo()

--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -608,22 +608,23 @@ public class FormTag extends GenericAttributesTagSupport {
 
         // サブミット用のスクリプトが登録されていた場合は、合わせて出力する。
         // CSP対応のため、HTMLタグの属性に直接出力するのではなくscriptタグ内に含める。
-        appendInlineOnclickSubmissionScripts(formContext, javaScript);
+        javaScript.append(createInlineOnclickSubmissionScripts(formContext));
 
         // サブミッション情報のスクリプトを追加する
-        appendSubmissionInfoScripts(formContext, attributes, javaScript);
+        javaScript.append(createSubmissionInfoScripts(formContext, attributes));
         
         TagUtil.print(pageContext, ls + TagUtil.createScriptTag(pageContext, javaScript.toString()));
     }
 
     /**
-     * {@link FormContext}内にサブミット用のスクリプトが登録されていた場合、引数の{@code javaScript}に
-     * スクリプトを追加する。
+     * {@link FormContext}内にサブミット用のスクリプトが登録されていた場合、スクリプトをまとめて返却する。
      *
      * @param formContext {@link FormContext}
-     * @param javaScript スクリプトを追加する{@link StringBuilder}
+     * @return まとめたサブミット用のスクリプト
      */
-    private void appendInlineOnclickSubmissionScripts(FormContext formContext, StringBuilder javaScript) {
+    private String createInlineOnclickSubmissionScripts(FormContext formContext) {
+        StringBuilder javaScript = new StringBuilder();
+
         String ls = TagUtil.getCustomTagConfig().getLineSeparator();
 
         List<String> inlineOnclickSubmissionScripts = formContext.getInlineSubmissionScripts();
@@ -634,17 +635,19 @@ public class FormTag extends GenericAttributesTagSupport {
 
             javaScript.append(ls).append(ls);
         }
+
+        return javaScript.toString();
     }
 
     /**
-     * {@link FormContext}内のサブミッション情報からスクリプトを生成し、{@code javaScript}に
-     * 追加する。
+     * {@link FormContext}内のサブミッション情報からスクリプトを生成して返却する。
      *
      * @param formContext {@link FormContext}
      * @param attributes 属性
-     * @param javaScript スクリプト追加対象
      */
-    private void appendSubmissionInfoScripts(FormContext formContext, HtmlAttributes attributes, StringBuilder javaScript) {
+    private String createSubmissionInfoScripts(FormContext formContext, HtmlAttributes attributes) {
+        StringBuilder javaScript = new StringBuilder();
+
         String ls = TagUtil.getCustomTagConfig().getLineSeparator();
         String formName = TagUtil.escapeHtml(attributes.get(HtmlAttribute.NAME), false);
 
@@ -686,6 +689,8 @@ public class FormTag extends GenericAttributesTagSupport {
             javaScript.append(ls);
         }
         javaScript.append("};");
+
+        return javaScript.toString();
     }
 
     /**

--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -184,6 +184,7 @@ public class FormTag extends GenericAttributesTagSupport {
      * 属性はHTMLエスケープして出力する。
      * </pre>
      */
+    @Override
     public int doStartTag() throws JspException {
         
         if (getAttributes().get(HtmlAttribute.METHOD) == null) {
@@ -262,6 +263,7 @@ public class FormTag extends GenericAttributesTagSupport {
      * ただし、method属性がgetかつ{@link CustomTagConfig}のuseGetRequestがtrueの場合は、上記処理は行わずに閉じタグのみを出力して処理を終了する。
      * </pre>
      */
+    @Override
     public int doEndTag() throws JspException {
         
         if (isGetRequest()) {
@@ -606,6 +608,24 @@ public class FormTag extends GenericAttributesTagSupport {
 
         // サブミット用のスクリプトが登録されていた場合は、合わせて出力する。
         // CSP対応のため、HTMLタグの属性に直接出力するのではなくscriptタグ内に含める。
+        appendInlineOnclickSubmissionScripts(formContext, javaScript);
+
+        // サブミッション情報のスクリプトを追加する
+        appendSubmissionInfoScripts(formContext, attributes, javaScript);
+        
+        TagUtil.print(pageContext, ls + TagUtil.createScriptTag(pageContext, javaScript.toString()));
+    }
+
+    /**
+     * {@link FormContext}内にサブミット用のスクリプトが登録されていた場合、引数の{@code javaScript}に
+     * スクリプトを追加する。
+     *
+     * @param formContext {@link FormContext}
+     * @param javaScript スクリプトを追加する{@link StringBuilder}
+     */
+    private void appendInlineOnclickSubmissionScripts(FormContext formContext, StringBuilder javaScript) {
+        String ls = TagUtil.getCustomTagConfig().getLineSeparator();
+
         List<String> inlineOnclickSubmissionScripts = formContext.getInlineSubmissionScripts();
         if (!inlineOnclickSubmissionScripts.isEmpty()) {
             for (String script : inlineOnclickSubmissionScripts) {
@@ -614,11 +634,22 @@ public class FormTag extends GenericAttributesTagSupport {
 
             javaScript.append(ls).append(ls);
         }
+    }
 
+    /**
+     * {@link FormContext}内のサブミッション情報からスクリプトを生成し、{@code javaScript}に
+     * 追加する。
+     *
+     * @param formContext {@link FormContext}
+     * @param attributes 属性
+     * @param javaScript スクリプト追加対象
+     */
+    private void appendSubmissionInfoScripts(FormContext formContext, HtmlAttributes attributes, StringBuilder javaScript) {
+        String ls = TagUtil.getCustomTagConfig().getLineSeparator();
         String formName = TagUtil.escapeHtml(attributes.get(HtmlAttribute.NAME), false);
-        
+
         javaScript.append(SUBMISSION_INFO_VAR).append(".").append(formName).append(" = {").append(ls);
-        List<SubmissionInfo> infoList = TagUtil.getFormContext(pageContext).getSubmissionInfoList();
+        List<SubmissionInfo> infoList = formContext.getSubmissionInfoList();
         for (int i = 0; i < infoList.size(); i++) {
             SubmissionInfo info = infoList.get(i);
             String hash;
@@ -627,13 +658,13 @@ public class FormTag extends GenericAttributesTagSupport {
                 String popupWindowName = info.getPopupWindowName();
                 String popupOption = info.getPopupOption();
                 hash = String.format(POPUP_SUBMISSION_INFO_HASH,
-                                     info.getName(),
-                                     info.getUri(),
-                                     info.isAllowDoubleSubmission(),
-                                     submissionAction.name(),
-                                     popupWindowName != null ? "\"" + popupWindowName + "\"" : null,
-                                     popupOption != null ? popupOption : "",
-                                     createChangeParamNamesHash(info.getChangeParamNames()));
+                        info.getName(),
+                        info.getUri(),
+                        info.isAllowDoubleSubmission(),
+                        submissionAction.name(),
+                        popupWindowName != null ? "\"" + popupWindowName + "\"" : null,
+                        popupOption != null ? popupOption : "",
+                        createChangeParamNamesHash(info.getChangeParamNames()));
             } else if (SubmissionAction.DOWNLOAD == submissionAction) {
                 hash = String.format(DOWNLOAD_SUBMISSION_INFO_HASH,
                         info.getName(),
@@ -643,10 +674,10 @@ public class FormTag extends GenericAttributesTagSupport {
                         createChangeParamNamesHash(info.getChangeParamNames()));
             } else {
                 hash = String.format(SUBMISSION_INFO_HASH,
-                                     info.getName(),
-                                     info.getUri(),
-                                     info.isAllowDoubleSubmission(),
-                                     submissionAction.name());
+                        info.getName(),
+                        info.getUri(),
+                        info.isAllowDoubleSubmission(),
+                        submissionAction.name());
             }
             javaScript.append(hash);
             if (i != infoList.size() - 1) {
@@ -655,8 +686,6 @@ public class FormTag extends GenericAttributesTagSupport {
             javaScript.append(ls);
         }
         javaScript.append("};");
-        
-        TagUtil.print(pageContext, ls + TagUtil.createScriptTag(pageContext, javaScript.toString()));
     }
 
     /**

--- a/src/main/java/nablarch/common/web/tag/FormTag.java
+++ b/src/main/java/nablarch/common/web/tag/FormTag.java
@@ -644,6 +644,7 @@ public class FormTag extends GenericAttributesTagSupport {
      *
      * @param formContext {@link FormContext}
      * @param attributes 属性
+     * @return 生成したスクリプト
      */
     private String createSubmissionInfoScripts(FormContext formContext, HtmlAttributes attributes) {
         StringBuilder javaScript = new StringBuilder();

--- a/src/main/java/nablarch/common/web/tag/ScriptTag.java
+++ b/src/main/java/nablarch/common/web/tag/ScriptTag.java
@@ -25,6 +25,7 @@ public class ScriptTag extends HtmlTagSupport {
      * XHTMLのid属性を設定する。
      * @param id XHTMLのid属性
      */
+    @Override
     public void setId(String id) {
         getAttributes().put(HtmlAttribute.ID, id);
     }
@@ -84,6 +85,7 @@ public class ScriptTag extends HtmlTagSupport {
      * 絶対URLでない場合は言語対応のリソースパスに変換する。
      * </pre>
      */
+    @Override
     public int doStartTag() throws JspException {
         if (!TagUtil.jsSupported(pageContext)) {
             return SKIP_BODY;
@@ -121,6 +123,7 @@ public class ScriptTag extends HtmlTagSupport {
      * 閉じタグを出力する。
      * </pre>
      */
+    @Override
     public int doEndTag() throws JspException {
         if (!TagUtil.jsSupported(pageContext)) {
             return EVAL_PAGE;

--- a/src/main/java/nablarch/common/web/tag/SubmitLinkTagSupport.java
+++ b/src/main/java/nablarch/common/web/tag/SubmitLinkTagSupport.java
@@ -100,6 +100,7 @@ public abstract class SubmitLinkTagSupport extends FocusAttributesTagSupport imp
      * ここで非活性とは、リンクを解除してラベルのみを表示することである。
      * </pre>
      */
+    @Override
     public int doStartTag() throws JspException {
         if (!TagUtil.jsSupported(pageContext)) {
            throw new JspException(
@@ -170,6 +171,7 @@ public abstract class SubmitLinkTagSupport extends FocusAttributesTagSupport imp
      * 閉じタグを出力する。
      * </pre>
      */
+    @Override
     public int doEndTag() throws JspException {
         DisplayMethod displayMethod = TagUtil.getFormContext(pageContext)
                                               .getCurrentSubmissionInfo()

--- a/src/main/java/nablarch/common/web/tag/SubmitTagSupport.java
+++ b/src/main/java/nablarch/common/web/tag/SubmitTagSupport.java
@@ -136,6 +136,7 @@ public abstract class SubmitTagSupport extends InputTagSupport {
      *   リクエストパラメータに差し替えられる。
      * </pre>
      */
+    @Override
     public int doStartTag() throws JspException {
         checkChildElementsOfForm();
 
@@ -210,6 +211,7 @@ public abstract class SubmitTagSupport extends InputTagSupport {
     /**
      * {@inheritDoc}
      */
+    @Override
     public int doEndTag() throws JspException {
         TagUtil.getFormContext(pageContext).setCurrentSubmissionInfo(null);
         return EVAL_PAGE;

--- a/src/main/java/nablarch/common/web/tag/TagUtil.java
+++ b/src/main/java/nablarch/common/web/tag/TagUtil.java
@@ -814,7 +814,6 @@ public final class TagUtil {
         }
 
         CustomTagConfig customTagConfig = TagUtil.getCustomTagConfig();
-        String ls = customTagConfig.getLineSeparator();
         FormContext formContext = getFormContext(pageContext);
         StringBuilder javaScript = new StringBuilder();
         javaScript.append("document.querySelector(\"");

--- a/src/test/java/nablarch/common/web/tag/ButtonTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/ButtonTagTest.java
@@ -568,11 +568,11 @@ public class ButtonTagTest extends TagTestSupport<ButtonTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
 
         TagTestUtil.setUpDefaultConfig();
 

--- a/src/test/java/nablarch/common/web/tag/DownloadButtonTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/DownloadButtonTagTest.java
@@ -286,11 +286,11 @@ public class DownloadButtonTagTest extends TagTestSupport<DownloadButtonTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);

--- a/src/test/java/nablarch/common/web/tag/DownloadLinkTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/DownloadLinkTagTest.java
@@ -273,11 +273,11 @@ public class DownloadLinkTagTest extends TagTestSupport<DownloadLinkTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);

--- a/src/test/java/nablarch/common/web/tag/DownloadSubmitTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/DownloadSubmitTagTest.java
@@ -335,11 +335,11 @@ public class DownloadSubmitTagTest extends TagTestSupport<DownloadSubmitTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);

--- a/src/test/java/nablarch/common/web/tag/PopupButtonTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/PopupButtonTagTest.java
@@ -352,11 +352,11 @@ public class PopupButtonTagTest extends TagTestSupport<PopupButtonTag> {
 
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);

--- a/src/test/java/nablarch/common/web/tag/PopupLinkTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/PopupLinkTagTest.java
@@ -361,11 +361,11 @@ public class PopupLinkTagTest extends TagTestSupport<PopupLinkTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);

--- a/src/test/java/nablarch/common/web/tag/PopupSubmitTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/PopupSubmitTagTest.java
@@ -359,11 +359,11 @@ public class PopupSubmitTagTest extends TagTestSupport<PopupSubmitTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);

--- a/src/test/java/nablarch/common/web/tag/SubmitLinkTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/SubmitLinkTagTest.java
@@ -805,11 +805,11 @@ public class SubmitLinkTagTest extends TagTestSupport<SubmitLinkTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);

--- a/src/test/java/nablarch/common/web/tag/SubmitTagTest.java
+++ b/src/test/java/nablarch/common/web/tag/SubmitTagTest.java
@@ -641,11 +641,11 @@ public class SubmitTagTest extends TagTestSupport<SubmitTag> {
     }
 
     /**
-     * SuppressCallNablarchSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
+     * suppressDefaultSubmit属性に{@code true}を指定した時に、CSPのnonceの有無に関わらず
      * サブミット用のスクリプトが出力されなくなることを確認する。
      */
     @Test
-    public void testInputPageForSuppressCallNablarchSubmit() throws Exception {
+    public void testInputPageForSuppressDefaultSubmit() throws Exception {
         TagTestUtil.setUpDefaultConfig();
         FormContext formContext = TagTestUtil.createFormContext();
         TagUtil.setFormContext(pageContext, formContext);


### PR DESCRIPTION
SonarQubeでの以下の指摘に対応しました。

- 不要な変数の削除
- `FormTag`でのCyclomatic Complexityの上限超過
  - JavaScriptの生成部分をメソッド分割した結果、差分では処理が削除されたように見えていますが元のメソッドに残っています
  - 変更前の659行目が変更後の616行目に移っています

加えて、以下の対応をしています。

- `@Override`がないことによる指摘が多かったので追加
- テストメソッド名とコメントがsuppressDefaultSubmit属性名の変更に追従できていなかったので変更